### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,12 +242,12 @@ variable to the JSON file path instead of adding the
 #### Scala
 
 Debugging Scala applications is supported; however, expressions and conditions
-conditions must be written using the Java programming language syntax.
+must be written using the Java programming language syntax.
 
 #### Kotlin
 
 Debugging Kotlin applications is supported; however, expressions and conditions
-conditions must be written using the Java programming language syntax.
+must be written using the Java programming language syntax.
 
 Many Kotlin-specific features can be used in conditions and expressions with
 simple workarounds:


### PR DESCRIPTION
This fixes a couple of minor documentation typos (repeated word "conditions").