### PR TITLE
Get rid of memory leaks from invoking JvmtiEnv::GetLocalVariableTable

### DIFF
--- a/src/agent/method_locals.cc
+++ b/src/agent/method_locals.cc
@@ -140,6 +140,14 @@ std::shared_ptr<MethodLocals::Entry> MethodLocals::LoadEntry(
   for (int i = 0; i < num_entries; ++i) {
     const jvmtiLocalVariableEntry& local_variable_entry = table.get()[i];
 
+    // Get rid of memory leaks because these buffer were malloc by JVM in function JvmtiEnv::GetLocalVariableTable (https://github.com/openjdk/jdk/blob/master/src/hotspot/share/prims/jvmtiEnv.cpp)
+    JvmtiBuffer<char> class_name;
+    JvmtiBuffer<char> class_signature;
+    JvmtiBuffer<char> class_generic;
+    *class_name.ref() = local_variable_entry.name;
+    *class_signature.ref() = local_variable_entry.signature;
+    *class_generic.ref() = local_variable_entry.generic_signature;
+
     if ((class_visibility != nullptr) &&
         !class_visibility->IsVariableVisible(
             method_name,


### PR DESCRIPTION
I found that GetLocalVariableTable call might be kind of dangerous because its buffer should be free many times. Look the code snippet from openjdk function JvmtiEnv::GetLocalVariableTable (https://github.com/openjdk/jdk/blob/master/src/hotspot/share/prims/jvmtiEnv.cpp).


```
// get utf8 name and signature
      char *name_buf = NULL;
      char *sig_buf = NULL;
      char *gen_sig_buf = NULL;
      {
        ResourceMark rm(current_thread);

        const char *utf8_name = (const char *) constants->symbol_at(name_index)->as_utf8();
        name_buf = (char *) jvmtiMalloc(strlen(utf8_name)+1);
        strcpy(name_buf, utf8_name);

        const char *utf8_signature = (const char *) constants->symbol_at(signature_index)->as_utf8();
        sig_buf = (char *) jvmtiMalloc(strlen(utf8_signature)+1);
        strcpy(sig_buf, utf8_signature);

        if (generic_signature_index > 0) {
          const char *utf8_gen_sign = (const char *)
                                       constants->symbol_at(generic_signature_index)->as_utf8();
          gen_sig_buf = (char *) jvmtiMalloc(strlen(utf8_gen_sign)+1);
          strcpy(gen_sig_buf, utf8_gen_sign);
        }
      }

      // fill in the jvmti local variable table
      jvmti_table[i].start_location = start_location;
      jvmti_table[i].length = length;
      jvmti_table[i].name = name_buf;
      jvmti_table[i].signature = sig_buf;
      jvmti_table[i].generic_signature = gen_sig_buf;
      jvmti_table[i].slot = slot;
```


So I think these memory should be free outside.
   