### PR TITLE
Implemented GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ jobs:
       runs-on: ubuntu-latest
       steps:
 
+        - name: Checkout repository
+          uses: actions/checkout@v2
+
         - name: Install dependencies
           run: |
             sudo apt-get -y -q --no-install-recommends install \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+    build:
+      name: Build
+      runs-on: ubuntu-latest
+      steps:
+
+        - name: Install dependencies
+          run: |
+            sudo apt-get -y -q --no-install-recommends install \
+            curl gcc build-essential libssl-dev unzip openjdk-8-jdk \
+            cmake python maven
+
+        - name: Build
+          run: ./build.sh
+
+        - name: Check for artifact
+          run: ls cdbg_java_agent_gce.tar.gz

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Java Cloud Debugger Agent
 
+![Build](https://github.com/GoogleCloudPlatform/cloud-debug-java/workflows/Build/badge.svg)
+
 Google [Cloud Debugger](https://cloud.google.com/debugger/) for Java.
 
 ## Overview


### PR DESCRIPTION
### GitHub Actions

Implemented a simple GitHub Actions workflow for running the build.sh script and a status badge for README.md.

A sucessful run can be seen [here](https://github.com/leozz37/cloud-debug-java/actions/runs/299099957).

![Build](https://github.com/leozz37/cloud-debug-java/workflows/Build/badge.svg)