### PR TITLE
chore: Add missing license.

### DIFF
--- a/src/agent/internals/src/test/java/com/google/devtools/cdbg/debuglets/java/GceMetadataQueryTest.java
+++ b/src/agent/internals/src/test/java/com/google/devtools/cdbg/debuglets/java/GceMetadataQueryTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.devtools.cdbg.debuglets.java;
 
 import static com.google.common.truth.Truth.assertThat;

--- a/src/agent/internals/src/test/java/com/google/devtools/cdbg/debuglets/java/YamlConfigParserTest.java
+++ b/src/agent/internals/src/test/java/com/google/devtools/cdbg/debuglets/java/YamlConfigParserTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.devtools.cdbg.debuglets.java;
 
 import static com.google.common.truth.Truth.assertThat;


### PR DESCRIPTION
Missed adding the copyright and license to the two recently added unit test files.