### PR TITLE
fix: Fix build.sh

### DIFF
--- a/src/agent/Makefile
+++ b/src/agent/Makefile
@@ -241,7 +241,7 @@ internals_class_loader_static_defs: internals_class_loader
 
 internals_jar:
 ifeq ($(JAVA_BUILD),maven)
-	cd internals ; mvn clean install
+	cd internals ; mvn -Dmaven.test.skip=true clean install
 	cp internals/target/cdbg_java_agent_internals-SNAPSHOT-jar-with-dependencies.jar $(INTERNALS_JAR)
 else
 	mkdir -p internals/target


### PR DESCRIPTION
The addition of the unit tests is causing build.sh to fail as maven is
attempting to build the tests. This is not needed.