### PR TITLE
Add unit tests for the JVariant class.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,8 +28,9 @@ maven_install(
         "com.google.firebase:firebase-admin:9.0.0",
         "com.google.truth:truth:1.1.3",
         "junit:junit:4.13.2",
-        "org.ow2.asm:asm:9.1",
+        "org.freemarker:freemarker:2.3.22",
         "org.mockito:mockito-core:4.6.1",
+        "org.ow2.asm:asm:9.1",
         "org.yaml:snakeyaml:1.32",
     ],
     repositories = [

--- a/build.sh
+++ b/build.sh
@@ -68,7 +68,6 @@ popd
 
 rm -rf "${ROOT}"/dist
 
-
 if [[ -n "${INSTALL_DEPS}" ]]; then
 apt-get update
 apt-get -y -q --no-install-recommends install \

--- a/src/agent/BUILD
+++ b/src/agent/BUILD
@@ -1,3 +1,5 @@
+package(default_visibility = ["//visibility:public"])
+
 cc_library(
     name = "common",
     textual_hdrs = [
@@ -8,6 +10,45 @@ cc_library(
         "//:jdk_headers",
         "@com_github_google_glog//:glog",
     ],
+)
+
+cc_library(
+    name = "nullable",
+    hdrs = ["nullable.h"],
+    deps = [
+        ":common",
+    ],
+)
+
+cc_library(
+    name = "jvmti_buffer",
+    hdrs = ["jvmti_buffer.h"],
+    deps = [
+        ":common",
+    ],
+)
+
+cc_library(
+    name = "jni_utils_h",
+    hdrs = ["jni_utils.h"],
+    deps = [
+        ":common",
+        ":nullable",
+    ],
+)
+
+cc_library(
+    name = "jni_utils",
+    srcs = ["jni_utils.cc"],
+    copts = ["-Isrc/agent", "-I$(BINDIR)/src/codegen/generated"],
+    deps = [
+        ":common",
+        ":jni_utils_h",
+        ":jvmti_buffer",
+        ":nullable",
+        "//src/codegen:jni_proxies",
+    ],
+    alwayslink = 1,
 )
 
 cc_library(
@@ -74,6 +115,46 @@ cc_library(
     hdrs = ["data_visibility_policy.h"],
     deps = [
         ":common",
+    ],
+)
+
+cc_library(
+    name = "mock_jni_env",
+    testonly = 1,
+    hdrs = ["mock_jni_env.h"],
+)
+
+cc_library(
+    name = "mock_jvmti_env",
+    testonly = 1,
+    srcs = ["mock_jvmti_env.cc"],
+    hdrs = ["mock_jvmti_env.h"],
+    deps = [
+        ":common",
+        "@com_google_googletest//:gtest_main",
+        "//:jdk_headers",
+    ],
+)
+
+cc_library(
+    name = "jvariant",
+    srcs = ["jvariant.cc"],
+    hdrs = ["jvariant.h"],
+    deps = [
+        ":common",
+        ":jni_utils",
+        ":jni_utils_h",
+    ],
+)
+
+cc_test(
+    name = "jvariant_test",
+    srcs = ["jvariant_test.cc"],
+    deps = [
+        ":jvariant",
+        ":mock_jvmti_env",
+        ":mock_jni_env",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 

--- a/src/agent/internals/src/main/java/com/google/devtools/cdbg/debuglets/java/BUILD
+++ b/src/agent/internals/src/main/java/com/google/devtools/cdbg/debuglets/java/BUILD
@@ -3,18 +3,23 @@ load("@rules_java//java:defs.bzl", "java_library")
 package(default_visibility = ["//visibility:public"])
 
 java_library(
+    name = "breakpoint_labels_provider",
+    srcs = ["BreakpointLabelsProvider.java"],
+)
+
+java_library(
     name = "datatype_converter",
     srcs = ["DataTypeConverter.java"],
 )
 
 java_library(
-    name = "gcp_debuglet_version",
-    srcs = ["GcpDebugletVersion.java"],
+    name = "dynamic_log_helper",
+    srcs = ["DynamicLogHelper.java"],
 )
 
 java_library(
-    name = "hub_client",
-    srcs = ["HubClient.java"],
+    name = "embed_class_loader",
+    srcs = ["EmbedClassLoader.java"],
 )
 
 java_library(
@@ -35,18 +40,17 @@ java_library(
 )
 
 java_library(
-    name = "gcp_hub_client",
-    srcs = ["GcpHubClient.java"],
+    name = "gcp_breakpoint_labels_provider",
+    srcs = ["GcpBreakpointLabelsProvider.java"],
     deps = [
+        ":breakpoint_labels_provider",
         ":gcp_debuglet_version",
-        ":gcp_environment",
-        ":gcp_metadata",
-        ":hub_client",
-        ":labels",
-        ":logger",
-        ":mapper",
-        "@maven//:com_google_code_gson_gson"
     ],
+)
+
+java_library(
+    name = "gcp_debuglet_version",
+    srcs = ["GcpDebugletVersion.java"],
 )
 
 java_library(
@@ -58,6 +62,21 @@ java_library(
         ":gcp_metadata",
         ":labels",
         ":logger",
+    ],
+)
+
+java_library(
+    name = "gcp_hub_client",
+    srcs = ["GcpHubClient.java"],
+    deps = [
+        ":gcp_debuglet_version",
+        ":gcp_environment",
+        ":gcp_metadata",
+        ":hub_client",
+        ":labels",
+        ":logger",
+        ":mapper",
+        "@maven//:com_google_code_gson_gson"
     ],
 )
 
@@ -75,6 +94,12 @@ java_library(
     ],
 )
 
+
+java_library(
+    name = "hub_client",
+    srcs = ["HubClient.java"],
+)
+
 java_library(
     name = "labels",
     srcs = ["Labels.java"],
@@ -84,6 +109,7 @@ java_library(
     name = "logger",
     srcs = ["AgentLogger.java"],
 )
+
 
 java_library(
     name = "mapper",
@@ -108,6 +134,16 @@ java_library(
 )
 
 java_library(
+    name = "statistician",
+    srcs = ["Statistician.java"],
+)
+
+java_library(
+    name = "user_id_provider",
+    srcs = ["UserIdProvider.java"],
+)
+
+java_library(
     name = "yaml_config_parser",
     srcs = [
         "YamlConfigParser.java",
@@ -119,3 +155,25 @@ java_library(
     ],
 )
 
+java_library(
+    name = "cdbg_java_agent_internals",
+    runtime_deps = [
+        ":breakpoint_labels_provider",
+        ":datatype_converter",
+        ":dynamic_log_helper",
+        ":embed_class_loader",
+        ":firebase_client",
+        ":gcp_breakpoint_labels_provider",
+        ":gcp_debuglet_version",
+        ":gcp_environment",
+        ":gcp_hub_client",
+        ":gcp_metadata",
+        ":hub_client",
+        ":labels",
+        ":logger",
+        ":mapper",
+        ":statistician",
+        ":user_id_provider",
+        "yaml_config_parser",
+    ],
+)

--- a/src/agent/jvariant_test.cc
+++ b/src/agent/jvariant_test.cc
@@ -1,0 +1,538 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "jvariant.h"
+
+#include "gmock/gmock.h"
+#include "mock_jni_env.h"
+#include "mock_jvmti_env.h"
+
+using testing::_;
+using testing::AtMost;
+using testing::Invoke;
+using testing::Return;
+
+namespace devtools {
+namespace cdbg {
+
+class JVariantTest : public ::testing::Test {
+ protected:
+  JVariantTest() : global_jvm_(&jvmti_, &jni_) {
+  }
+
+  void SetUp() override {
+    EXPECT_CALL(jni_, NewLocalRef(_))
+        .WillRepeatedly(Invoke([] (jobject obj) {
+          return obj;
+        }));
+  }
+
+  template <typename T>
+  static void VerifyJVariant(const JVariant& jvariant, T expected_value) {
+    T actual_value;
+    ASSERT_TRUE(jvariant.get<T>(&actual_value));
+    EXPECT_EQ(expected_value, actual_value);
+  }
+
+ protected:
+  MockJNIEnv jni_;
+  MockJvmtiEnv jvmti_;
+  GlobalJvmEnv global_jvm_;
+};
+
+
+TEST_F(JVariantTest, DefaultConstructor) {
+  JVariant v;
+  EXPECT_EQ(JType::Void, v.type());
+}
+
+
+TEST_F(JVariantTest, Constructor_jboolean) {
+  VerifyJVariant<jboolean>(JVariant::Boolean(true), true);
+  VerifyJVariant<jboolean>(JVariant::Boolean(false), false);
+}
+
+
+TEST_F(JVariantTest, Constructor_jbyte) {
+  VerifyJVariant<jbyte>(JVariant::Byte(-119), -119);
+}
+
+
+TEST_F(JVariantTest, Constructor_jchar) {
+  VerifyJVariant<jchar>(JVariant::Char(52345), 52345);
+}
+
+
+TEST_F(JVariantTest, Constructor_jshort) {
+  VerifyJVariant<jshort>(JVariant::Short(-12345), -12345);
+}
+
+
+TEST_F(JVariantTest, Constructor_jint) {
+  VerifyJVariant<jint>(JVariant::Int(12345678), 12345678);
+}
+
+
+TEST_F(JVariantTest, Constructor_jlong) {
+  VerifyJVariant<jlong>(JVariant::Long(0x1234123412), 0x1234123412);
+}
+
+
+TEST_F(JVariantTest, Constructor_jfloat) {
+  VerifyJVariant<jfloat>(JVariant::Float(1.1f), 1.1f);
+}
+
+
+TEST_F(JVariantTest, Constructor_jdouble) {
+  VerifyJVariant<jdouble>(JVariant::Double(3.1415), 3.1415);
+}
+
+
+TEST_F(JVariantTest, ConstructorJObjectLocalReference) {
+  const jobject kLocalRef = reinterpret_cast<jobject>(3478534785);
+  JVariant jvariant = JVariant::LocalRef(kLocalRef);
+  VerifyJVariant<jobject>(jvariant, kLocalRef);
+
+  EXPECT_CALL(jni_, DeleteLocalRef(kLocalRef))
+      .WillOnce(Return());
+}
+
+
+TEST_F(JVariantTest, ConstructorJObjectGlobalReference) {
+  const jobject kGlobalRef = reinterpret_cast<jobject>(3478534785);
+  JVariant jvariant = JVariant::GlobalRef(kGlobalRef);
+  VerifyJVariant<jobject>(jvariant, kGlobalRef);
+
+  EXPECT_CALL(jni_, DeleteGlobalRef(kGlobalRef))
+      .WillOnce(Return());
+}
+
+
+TEST_F(JVariantTest, swap) {
+  JVariant v1 = JVariant::Int(34857643);
+  JVariant v2 = JVariant::Boolean(true);
+
+  v1.swap(&v2);
+
+  VerifyJVariant<jboolean>(v1, true);
+  VerifyJVariant<jint>(v2, 34857643);
+}
+
+
+TEST_F(JVariantTest, type) {
+  EXPECT_EQ(JType::Boolean, JVariant::Boolean(true).type());
+  EXPECT_EQ(JType::Byte, JVariant::Byte(-119).type());
+  EXPECT_EQ(JType::Char, JVariant::Char(52345).type());
+  EXPECT_EQ(JType::Short, JVariant::Short(-12345).type());
+  EXPECT_EQ(JType::Int, JVariant::Int(12345678).type());
+  EXPECT_EQ(JType::Long, JVariant::Long(0x1234123412).type());
+  EXPECT_EQ(JType::Float, JVariant::Float(1.1f).type());
+  EXPECT_EQ(JType::Double, JVariant::Double(3.1415).type());
+  EXPECT_EQ(JType::Object, JVariant::Null().type());
+}
+
+
+TEST_F(JVariantTest, get_WrongType) {
+  JVariant stock_jvariants[] = {
+    JVariant::Boolean(true),
+    JVariant::Byte(-119),
+    JVariant::Char(52345),
+    JVariant::Short(-12345),
+    JVariant::Int(12345678),
+    JVariant::Long(0x1234123412),
+    JVariant::Float(1.1f),
+    JVariant::Double(3.1415),
+    JVariant::Null()
+  };
+
+  for (const JVariant& jvariant : stock_jvariants) {
+    if (jvariant.type() != JType::Boolean) {
+      jboolean value;
+      EXPECT_FALSE(jvariant.get<jboolean>(&value));
+    }
+
+    if (jvariant.type() != JType::Byte) {
+      jbyte value;
+      EXPECT_FALSE(jvariant.get<jbyte>(&value));
+    }
+
+    if (jvariant.type() != JType::Char) {
+      jchar value;
+      EXPECT_FALSE(jvariant.get<jchar>(&value));
+    }
+
+    if (jvariant.type() != JType::Short) {
+      jshort value;
+      EXPECT_FALSE(jvariant.get<jshort>(&value));
+    }
+
+    if (jvariant.type() != JType::Int) {
+      jint value;
+      EXPECT_FALSE(jvariant.get<jint>(&value));
+    }
+
+    if (jvariant.type() != JType::Long) {
+      jlong value;
+      EXPECT_FALSE(jvariant.get<jlong>(&value));
+    }
+
+    if (jvariant.type() != JType::Float) {
+      jfloat value;
+      EXPECT_FALSE(jvariant.get<jfloat>(&value));
+    }
+
+    if (jvariant.type() != JType::Double) {
+      jdouble value;
+      EXPECT_FALSE(jvariant.get<jdouble>(&value));
+    }
+
+    if (jvariant.type() != JType::Object) {
+      jobject value;
+      EXPECT_FALSE(jvariant.get<jobject>(&value));
+    }
+  }
+}
+
+
+TEST_F(JVariantTest, has_non_null_object) {
+  const jobject kLocalRef = reinterpret_cast<jobject>(11111);
+
+  EXPECT_FALSE(JVariant::Boolean(true).has_non_null_object());
+  EXPECT_FALSE(JVariant::Float(1.23f).has_non_null_object());
+
+  EXPECT_FALSE(JVariant::Null().has_non_null_object());
+
+  EXPECT_CALL(jni_, DeleteLocalRef(kLocalRef)).Times(1);
+  EXPECT_TRUE(JVariant::LocalRef(kLocalRef).has_non_null_object());
+}
+
+
+TEST_F(JVariantTest, assign_jboolean) {
+  JVariant v;
+  v = JVariant::Boolean(true);
+  VerifyJVariant<jboolean>(v, true);
+}
+
+
+TEST_F(JVariantTest, assign_jbyte) {
+  JVariant v;
+  v = JVariant::Byte(-119);
+  VerifyJVariant<jbyte>(v, -119);
+}
+
+
+TEST_F(JVariantTest, assign_jchar) {
+  JVariant v;
+  v = JVariant::Char(52345);
+  VerifyJVariant<jchar>(v, 52345);
+}
+
+
+TEST_F(JVariantTest, assign_jshort) {
+  JVariant v;
+  v = JVariant::Short(-12345);
+  VerifyJVariant<jshort>(v, -12345);
+}
+
+
+TEST_F(JVariantTest, assign_jint) {
+  JVariant v;
+  v = JVariant::Int(12345678);
+  VerifyJVariant<jint>(v, 12345678);
+}
+
+
+TEST_F(JVariantTest, assign_jlong) {
+  JVariant v;
+  v = JVariant::Long(0x1234123412);
+  VerifyJVariant<jlong>(v, 0x1234123412);
+}
+
+
+TEST_F(JVariantTest, assign_jfloat) {
+  JVariant v;
+  v = JVariant::Float(1.1f);
+  VerifyJVariant<jfloat>(v, 1.1f);
+}
+
+
+TEST_F(JVariantTest, assign_jdouble) {
+  JVariant v;
+  v = JVariant::Double(3.1415);
+  VerifyJVariant<jdouble>(v, 3.1415);
+}
+
+
+TEST_F(JVariantTest, assign_JVariant_jobject) {
+  const jobject kLocalRef1 = reinterpret_cast<jobject>(11111);
+  const jobject kLocalRef2a = reinterpret_cast<jobject>(22222);
+  const jobject kLocalRef2b = reinterpret_cast<jobject>(22222);
+
+  JVariant jvariant1 = JVariant::LocalRef(kLocalRef1);
+  JVariant jvariant2 = JVariant::LocalRef(kLocalRef2a);
+
+  EXPECT_CALL(jni_, DeleteLocalRef(kLocalRef1)).Times(1);
+  EXPECT_CALL(jni_, NewLocalRef(kLocalRef2a)).WillOnce(Return(kLocalRef2b));
+
+  jvariant1 = JVariant(jvariant2);
+
+  VerifyJVariant<jobject>(jvariant1, kLocalRef2b);
+
+  EXPECT_CALL(jni_, DeleteLocalRef(kLocalRef2b)).Times(1);
+  jvariant1.ReleaseRef();
+
+  EXPECT_CALL(jni_, DeleteLocalRef(kLocalRef2a)).Times(1);
+  jvariant2.ReleaseRef();
+}
+
+
+TEST_F(JVariantTest, assign_JVariant_boolean) {
+  const jobject kLocalRef = reinterpret_cast<jobject>(11111);
+
+  JVariant jvariant1 = JVariant::LocalRef(kLocalRef);
+  JVariant jvariant2 = JVariant::Boolean(true);
+
+  EXPECT_CALL(jni_, DeleteLocalRef(kLocalRef)).Times(1);
+  jvariant1 = JVariant(jvariant2);
+
+  VerifyJVariant<jboolean>(jvariant1, true);
+}
+
+
+TEST_F(JVariantTest, change_ref_type_PrimitiveType) {
+  JVariant jvariant = JVariant::Boolean(true);
+  jvariant.change_ref_type(JVariant::ReferenceKind::Global);
+
+  VerifyJVariant<jboolean>(jvariant, true);
+}
+
+
+TEST_F(JVariantTest, AttachGlobalRef) {
+  const jobject kLocalRef = reinterpret_cast<jobject>(0x1111);
+  const jobject kGlobalRef = reinterpret_cast<jobject>(0x2222);
+
+  jobject ref = nullptr;
+
+  JVariant jvariant = JVariant::LocalRef(kLocalRef);
+
+  EXPECT_CALL(jni_, GetObjectRefType(kGlobalRef))
+      .Times(AtMost(1))
+      .WillRepeatedly(Return(JNIGlobalRefType));
+
+  EXPECT_CALL(jni_, DeleteLocalRef(kLocalRef))
+      .WillOnce(Return());
+
+  jvariant.attach_ref(JVariant::ReferenceKind::Global, kGlobalRef);
+
+  EXPECT_TRUE(jvariant.get<jobject>(&ref));
+  EXPECT_EQ(kGlobalRef, ref);
+
+  EXPECT_CALL(jni_, DeleteGlobalRef(kGlobalRef))
+      .WillOnce(Return());
+
+  jvariant.ReleaseRef();
+}
+
+
+TEST_F(JVariantTest, change_ref_type_LocalToGlobal) {
+  const jobject kLocalRef = reinterpret_cast<jobject>(0x1111);
+  const jobject kGlobalRef = reinterpret_cast<jobject>(0x2222);
+
+  jobject ref = nullptr;
+
+  JVariant jvariant = JVariant::LocalRef(kLocalRef);
+
+  EXPECT_TRUE(jvariant.get<jobject>(&ref));
+  EXPECT_EQ(kLocalRef, ref);
+
+  EXPECT_CALL(jni_, NewGlobalRef(kLocalRef))
+      .WillOnce(Return(kGlobalRef));
+  EXPECT_CALL(jni_, DeleteLocalRef(kLocalRef))
+      .WillOnce(Return());
+
+  jvariant.change_ref_type(JVariant::ReferenceKind::Global);
+
+  EXPECT_TRUE(jvariant.get<jobject>(&ref));
+  EXPECT_EQ(kGlobalRef, ref);
+
+  EXPECT_CALL(jni_, DeleteGlobalRef(kGlobalRef))
+      .WillOnce(Return());
+}
+
+
+TEST_F(JVariantTest, jvalue_jboolean) {
+  JVariant v;
+
+  v = JVariant::Boolean(true);
+  EXPECT_EQ(JNI_TRUE, v.get_jvalue().z);
+
+  v = JVariant::Boolean(false);
+  EXPECT_EQ(JNI_FALSE, v.get_jvalue().z);
+}
+
+
+TEST_F(JVariantTest, jvalue_jobject) {
+  const jobject kLocalRef = reinterpret_cast<jobject>(0x1111);
+  JVariant jvariant = JVariant::LocalRef(kLocalRef);
+
+  EXPECT_EQ(kLocalRef, jvariant.get_jvalue().l);
+
+  EXPECT_CALL(jni_, DeleteLocalRef(kLocalRef))
+      .WillOnce(Return());
+
+  jvariant.ReleaseRef();
+}
+
+
+TEST_F(JVariantTest, ToString) {
+  const struct {
+    JVariant jvariant;
+    std::string concise_str;
+    std::string long_str;
+  } test_cases[] = {
+    {
+      JVariant::Boolean(true),
+      "true",
+      "<boolean>true",
+    },
+    {
+      JVariant::Byte(-119),
+      "-119",
+      "<byte>-119"
+    },
+    {
+      JVariant::Char(52345),
+      "52345",
+      "<char>52345"
+    },
+    {
+      JVariant::Short(-12345),
+      "-12345",
+      "<short>-12345"
+    },
+    {
+      JVariant::Int(12345678),
+      "12345678",
+      "<int>12345678"
+    },
+    {
+      JVariant::Long(0x1234123412),
+      "78183019538",
+      "<long>78183019538"
+    },
+    {
+      JVariant::Float(1.1f),
+      "1.1",
+      "<float>1.1"
+    },
+    {
+      JVariant::Double(3.1415),
+      "3.1415",
+      "<double>3.1415"
+    },
+    {
+      JVariant::Null(),
+      "null",
+      "null"
+    }
+  };
+
+  for (const auto& test_case : test_cases) {
+    EXPECT_EQ(test_case.concise_str, test_case.jvariant.ToString(true));
+    EXPECT_EQ(test_case.long_str, test_case.jvariant.ToString(false));
+  }
+}
+
+
+TEST_F(JVariantTest, MoveLocalRef) {
+  const jobject kLocalRef = reinterpret_cast<jobject>(0x1111);
+  JVariant jvariant1 = JVariant::LocalRef(kLocalRef);
+
+  jobject obj = nullptr;
+
+  JVariant jvariant2(std::move(jvariant1));
+  EXPECT_EQ(JType::Void, jvariant1.type());
+  EXPECT_TRUE(jvariant2.get<jobject>(&obj) && (obj == kLocalRef));
+
+  EXPECT_CALL(jni_, DeleteLocalRef(kLocalRef))
+      .WillOnce(Return());
+}
+
+
+TEST_F(JVariantTest, MoveGlobalRef) {
+  const jobject kGlobalRef = reinterpret_cast<jobject>(0x2222);
+  JVariant jvariant1 = JVariant::GlobalRef(kGlobalRef);
+
+  jobject obj = nullptr;
+
+  JVariant jvariant2(std::move(jvariant1));
+  EXPECT_EQ(JType::Void, jvariant1.type());
+  EXPECT_TRUE(jvariant2.get<jobject>(&obj) && (obj == kGlobalRef));
+
+  EXPECT_CALL(jni_, DeleteGlobalRef(kGlobalRef))
+      .WillOnce(Return());
+}
+
+
+TEST_F(JVariantTest, JVariantMoveInt) {
+  JVariant jvariant1 = JVariant::Int(732);
+
+  jint int_value = 0;
+
+  JVariant jvariant2(std::move(jvariant1));
+  EXPECT_EQ(JType::Void, jvariant1.type());
+  EXPECT_EQ(JType::Int, jvariant2.type());
+  EXPECT_TRUE(jvariant2.get(&int_value) && (int_value == 732));
+}
+
+
+TEST_F(JVariantTest, MoveAssignRef) {
+  const jobject kGlobalRef = reinterpret_cast<jobject>(0x2222);
+  JVariant jvariant1 = JVariant::GlobalRef(kGlobalRef);
+
+  jobject obj = nullptr;
+
+  JVariant jvariant2 = JVariant::Int(18);
+  jvariant2 = std::move(jvariant1);
+  EXPECT_EQ(JType::Void, jvariant1.type());
+  EXPECT_TRUE(jvariant2.get<jobject>(&obj) && (obj == kGlobalRef));
+
+  EXPECT_CALL(jni_, DeleteGlobalRef(kGlobalRef))
+      .WillOnce(Return());
+}
+
+
+TEST_F(JVariantTest, BorrowedRef) {
+  const jobject kRef = reinterpret_cast<jobject>(0x384956834L);
+
+  EXPECT_CALL(jni_, NewLocalRef(_)).Times(0);
+  EXPECT_CALL(jni_, NewGlobalRef(_)).Times(0);
+  EXPECT_CALL(jni_, NewWeakGlobalRef(_)).Times(0);
+  EXPECT_CALL(jni_, DeleteLocalRef(_)).Times(0);
+  EXPECT_CALL(jni_, DeleteGlobalRef(_)).Times(0);
+  EXPECT_CALL(jni_, DeleteWeakGlobalRef(_)).Times(0);
+
+  const JVariant& jvariant = JVariant::BorrowedRef(kRef);
+
+  jobject obj = nullptr;
+  EXPECT_TRUE(jvariant.get<jobject>(&obj));
+  EXPECT_EQ(kRef, obj);
+}
+
+
+}  // namespace cdbg
+}  // namespace devtools
+

--- a/src/agent/mock_jni_env.h
+++ b/src/agent/mock_jni_env.h
@@ -1,18 +1,18 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// Disclaimer: This is not an official Google product.
+/**
+ * Copyright 2022 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #ifndef DEVTOOLS_CDBG_DEBUGLETS_JAVA_MOCK_JNI_ENV_H_
 #define DEVTOOLS_CDBG_DEBUGLETS_JAVA_MOCK_JNI_ENV_H_
@@ -56,21 +56,27 @@ class MockableJNIEnv : public JNIEnv {
   static void JNICALL CallDeleteGlobalRef(JNIEnv* env, jobject gref) {
     static_cast<MockableJNIEnv*>(env)->DeleteGlobalRef(gref);
   }
+
   static void JNICALL CallDeleteLocalRef(JNIEnv* env, jobject obj) {
     static_cast<MockableJNIEnv*>(env)->DeleteLocalRef(obj);
   }
+
   static void JNICALL CallDeleteWeakGlobalRef(JNIEnv* env, jweak ref) {
     static_cast<MockableJNIEnv*>(env)->DeleteWeakGlobalRef(ref);
   }
+
   static jobjectRefType JNICALL CallGetObjectRefType(JNIEnv* env, jobject obj) {
     return static_cast<MockableJNIEnv*>(env)->GetObjectRefType(obj);
   }
+
   static jobject JNICALL CallNewGlobalRef(JNIEnv* env, jobject lobj) {
     return static_cast<MockableJNIEnv*>(env)->NewGlobalRef(lobj);
   }
+
   static jobject JNICALL CallNewLocalRef(JNIEnv* env, jobject ref) {
     return static_cast<MockableJNIEnv*>(env)->NewLocalRef(ref);
   }
+
   static jweak JNICALL CallNewWeakGlobalRef(JNIEnv* env, jobject obj) {
     return static_cast<MockableJNIEnv*>(env)->NewWeakGlobalRef(obj);
   }

--- a/src/agent/mock_jni_env.h
+++ b/src/agent/mock_jni_env.h
@@ -1,0 +1,95 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Disclaimer: This is not an official Google product.
+
+#ifndef DEVTOOLS_CDBG_DEBUGLETS_JAVA_MOCK_JNI_ENV_H_
+#define DEVTOOLS_CDBG_DEBUGLETS_JAVA_MOCK_JNI_ENV_H_
+
+#include <jni.h>
+
+#include "gmock/gmock.h"
+
+namespace devtools {
+namespace cdbg {
+
+// JNIEnv interface is structure with pointers to functions, not a pure virtual
+// C++ class that can be mocked. To work around this problem, we create a
+// a pure virtual function for each JNIEnv function we care about and point
+// to it in the function table.
+// NOTE: this class does not include all the JNIEnv methods, but only the few
+// that are used by the agent.
+class MockableJNIEnv : public JNIEnv {
+ public:
+  MockableJNIEnv() {
+    functions = &functions_;
+    functions_.DeleteGlobalRef = &CallDeleteGlobalRef;
+    functions_.DeleteLocalRef = &CallDeleteLocalRef;
+    functions_.DeleteWeakGlobalRef = &CallDeleteWeakGlobalRef;
+    functions_.GetObjectRefType = &CallGetObjectRefType;
+    functions_.NewGlobalRef = &CallNewGlobalRef;
+    functions_.NewLocalRef = &CallNewLocalRef;
+    functions_.NewWeakGlobalRef = &CallNewWeakGlobalRef;
+  }
+  virtual ~MockableJNIEnv() {}
+
+  virtual void DeleteGlobalRef(jobject gref) = 0;
+  virtual void DeleteLocalRef(jobject obj) = 0;
+  virtual void DeleteWeakGlobalRef(jweak ref) = 0;
+  virtual jobjectRefType GetObjectRefType(jobject obj) = 0;
+  virtual jobject NewGlobalRef(jobject lobj) = 0;
+  virtual jobject NewLocalRef(jobject ref) = 0;
+  virtual jweak NewWeakGlobalRef(jobject obj) = 0;
+
+ private:
+  static void JNICALL CallDeleteGlobalRef(JNIEnv* env, jobject gref) {
+    static_cast<MockableJNIEnv*>(env)->DeleteGlobalRef(gref);
+  }
+  static void JNICALL CallDeleteLocalRef(JNIEnv* env, jobject obj) {
+    static_cast<MockableJNIEnv*>(env)->DeleteLocalRef(obj);
+  }
+  static void JNICALL CallDeleteWeakGlobalRef(JNIEnv* env, jweak ref) {
+    static_cast<MockableJNIEnv*>(env)->DeleteWeakGlobalRef(ref);
+  }
+  static jobjectRefType JNICALL CallGetObjectRefType(JNIEnv* env, jobject obj) {
+    return static_cast<MockableJNIEnv*>(env)->GetObjectRefType(obj);
+  }
+  static jobject JNICALL CallNewGlobalRef(JNIEnv* env, jobject lobj) {
+    return static_cast<MockableJNIEnv*>(env)->NewGlobalRef(lobj);
+  }
+  static jobject JNICALL CallNewLocalRef(JNIEnv* env, jobject ref) {
+    return static_cast<MockableJNIEnv*>(env)->NewLocalRef(ref);
+  }
+  static jweak JNICALL CallNewWeakGlobalRef(JNIEnv* env, jobject obj) {
+    return static_cast<MockableJNIEnv*>(env)->NewWeakGlobalRef(obj);
+  }
+
+  JNINativeInterface_ functions_;
+};
+
+class MockJNIEnv : public MockableJNIEnv {
+ public:
+  MOCK_METHOD(void, DeleteGlobalRef, (jobject gref), (override));
+  MOCK_METHOD(void, DeleteLocalRef, (jobject obj), (override));
+  MOCK_METHOD(void, DeleteWeakGlobalRef, (jweak ref), (override));
+  MOCK_METHOD(jobjectRefType, GetObjectRefType, (jobject obj), (override));
+  MOCK_METHOD(jobject, NewGlobalRef, (jobject lobj), (override));
+  MOCK_METHOD(jobject, NewLocalRef, (jobject ref), (override));
+  MOCK_METHOD(jweak, NewWeakGlobalRef, (jobject obj), (override));
+};
+
+}  // namespace cdbg
+}  // namespace devtools
+
+#endif  // DEVTOOLS_CDBG_DEBUGLETS_JAVA_MOCK_JNI_ENV_H_

--- a/src/agent/mock_jvmti_env.cc
+++ b/src/agent/mock_jvmti_env.cc
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "common.h"
+#include "mock_jvmti_env.h"
+
+namespace devtools {
+namespace cdbg {
+
+// Either the test mocks are thread safe or the test is single threaded. Either
+// way we don't need to bother with thread local storage here.
+static jvmtiEnv* g_jvmti = nullptr;
+static JNIEnv* g_jni = nullptr;
+
+jvmtiEnv* jvmti() {
+  CHECK(g_jvmti != nullptr);
+  return g_jvmti;
+}
+
+JNIEnv* jni() {
+  CHECK(g_jni != nullptr);
+  return g_jni;
+}
+
+JNIEnv* set_thread_jni(JNIEnv* jni) {
+  CHECK_EQ(g_jni, jni);
+  return g_jni;
+}
+
+
+bool BindSystemClasses() {
+  return true;
+}
+
+
+void CleanupSystemClasses() {}
+
+
+jobject GetSystemClassLoader() {
+  return nullptr;
+}
+
+
+GlobalJvmEnv::GlobalJvmEnv(jvmtiEnv* jvmti, JNIEnv* jni) {
+  CHECK(g_jvmti == nullptr);
+  CHECK(g_jni == nullptr);
+
+  g_jvmti = jvmti;
+  g_jni = jni;
+}
+
+
+GlobalJvmEnv::~GlobalJvmEnv() {
+  DCHECK(g_jvmti != nullptr);
+  DCHECK(g_jni != nullptr);
+
+  g_jvmti = nullptr;
+  g_jni = nullptr;
+}
+
+
+GlobalNoJni::GlobalNoJni()
+    : original_jni_(jni()) {
+  g_jni = nullptr;
+}
+
+GlobalNoJni::~GlobalNoJni() {
+  g_jni = original_jni_;
+}
+
+
+}  // namespace cdbg
+}  // namespace devtools
+

--- a/src/agent/mock_jvmti_env.h
+++ b/src/agent/mock_jvmti_env.h
@@ -1,0 +1,830 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DEVTOOLS_CDBG_DEBUGLETS_JAVA_MOCK_JVMTI_ENV_H_
+#define DEVTOOLS_CDBG_DEBUGLETS_JAVA_MOCK_JVMTI_ENV_H_
+
+#include <jni.h>
+#include <jvmti.h>
+
+#include "gmock/gmock.h"
+
+namespace devtools {
+namespace cdbg {
+
+// JVMTI interface is structure with pointers to functions, not a pure virtual
+// C++ class that can be mocked. To work around this problem, we create a
+// a pure virtual function for each JVMTI function we care about and point
+// to it in the function table.
+// NOTE: this class does not include all the JVMTI methods, but only the few
+// that are used by the agent.
+class MockableJvmtiEnv : public _jvmtiEnv {
+ public:
+  MockableJvmtiEnv() {
+    functions = &functions_;
+
+    memset(&functions_, 0, sizeof(functions_));
+    functions_.SetEventNotificationMode = &SetEventNotificationMode;
+    functions_.RunAgentThread = &RunAgentThread;
+    functions_.GetLocalObject = &GetLocalObject;
+    functions_.GetLocalInt = &GetLocalInt;
+    functions_.GetLocalLong = &GetLocalLong;
+    functions_.GetLocalFloat = &GetLocalFloat;
+    functions_.GetLocalDouble = &GetLocalDouble;
+    functions_.SetBreakpoint = &SetBreakpoint;
+    functions_.ClearBreakpoint = &ClearBreakpoint;
+    functions_.Deallocate = &Deallocate;
+    functions_.GetClassSignature = &GetClassSignature;
+    functions_.GetClassStatus = &GetClassStatus;
+    functions_.GetSourceFileName = &GetSourceFileName;
+    functions_.GetClassModifiers = &GetClassModifiers;
+    functions_.GetClassMethods = &GetClassMethods;
+    functions_.GetClassFields = &GetClassFields;
+    functions_.GetImplementedInterfaces = &GetImplementedInterfaces;
+    functions_.IsInterface = &IsInterface;
+    functions_.IsArrayClass = &IsArrayClass;
+    functions_.GetClassLoader = &GetClassLoader;
+    functions_.GetObjectHashCode = &GetObjectHashCode;
+    functions_.GetObjectMonitorUsage = &GetObjectMonitorUsage;
+    functions_.GetFieldName = &GetFieldName;
+    functions_.GetFieldDeclaringClass = &GetFieldDeclaringClass;
+    functions_.GetFieldModifiers = &GetFieldModifiers;
+    functions_.IsFieldSynthetic = &IsFieldSynthetic;
+    functions_.GetMethodName = &GetMethodName;
+    functions_.GetMethodDeclaringClass = &GetMethodDeclaringClass;
+    functions_.GetMethodModifiers = &GetMethodModifiers;
+    functions_.GetMaxLocals = &GetMaxLocals;
+    functions_.GetArgumentsSize = &GetArgumentsSize;
+    functions_.GetLineNumberTable = &GetLineNumberTable;
+    functions_.GetMethodLocation = &GetMethodLocation;
+    functions_.GetLocalVariableTable = &GetLocalVariableTable;
+    functions_.GetLoadedClasses = &GetLoadedClasses;
+    functions_.GetAllStackTraces = &GetAllStackTraces;
+    functions_.GetThreadListStackTraces = &GetThreadListStackTraces;
+    functions_.GetThreadLocalStorage = &GetThreadLocalStorage;
+    functions_.SetThreadLocalStorage = &SetThreadLocalStorage;
+    functions_.GetStackTrace = &GetStackTrace;
+    functions_.AddCapabilities = &AddCapabilities;
+    functions_.GetFrameLocation = &GetFrameLocation;
+    functions_.GetErrorName = &GetErrorName;
+  }
+
+  virtual ~MockableJvmtiEnv() { }
+
+  virtual jvmtiError SetEventNotificationMode(
+      jvmtiEventMode mode,
+      jvmtiEvent event_type,
+      jthread event_thread) = 0;
+
+  virtual jvmtiError RunAgentThread(
+      jthread thread,
+      jvmtiStartFunction proc,
+      const void* arg,
+      jint priority) = 0;
+
+  virtual jvmtiError GetLocalObject(
+      jthread thread,
+      jint depth,
+      jint slot,
+      jobject* value_ptr) = 0;
+
+  virtual jvmtiError GetLocalInt(
+      jthread thread,
+      jint depth,
+      jint slot,
+      jint* value_ptr) = 0;
+
+  virtual jvmtiError GetLocalLong(
+      jthread thread,
+      jint depth,
+      jint slot,
+      jlong* value_ptr) = 0;
+
+  virtual jvmtiError GetLocalFloat(
+      jthread thread,
+      jint depth,
+      jint slot,
+      jfloat* value_ptr) = 0;
+
+  virtual jvmtiError GetLocalDouble(
+      jthread thread,
+      jint depth,
+      jint slot,
+      jdouble* value_ptr) = 0;
+
+  virtual jvmtiError SetBreakpoint(
+      jmethodID method,
+      jlocation location) = 0;
+
+  virtual jvmtiError ClearBreakpoint(
+      jmethodID method,
+      jlocation location) = 0;
+
+  virtual jvmtiError Deallocate(
+      unsigned char* mem) = 0;
+
+  virtual jvmtiError GetClassSignature(
+      jclass klass,
+      char** signature_ptr,
+      char** generic_ptr) = 0;
+
+  virtual jvmtiError GetClassStatus(
+      jclass klass,
+      jint* status_ptr) = 0;
+
+  virtual jvmtiError GetSourceFileName(
+      jclass klass,
+      char** source_name_ptr) = 0;
+
+  virtual jvmtiError GetClassModifiers(
+      jclass klass,
+      jint* modifiers_ptr) = 0;
+
+  virtual jvmtiError GetClassMethods(
+      jclass klass,
+      jint* method_count_ptr,
+      jmethodID** methods_ptr) = 0;
+
+  virtual jvmtiError GetClassFields(
+      jclass klass,
+      jint* field_count_ptr,
+      jfieldID** fields_ptr) = 0;
+
+  virtual jvmtiError GetImplementedInterfaces(
+      jclass klass,
+      jint* interface_count_ptr,
+      jclass** interfaces_ptr) = 0;
+
+  virtual jvmtiError IsInterface(
+      jclass klass,
+      jboolean* is_interface_ptr) = 0;
+
+  virtual jvmtiError IsArrayClass(
+      jclass klass,
+      jboolean* is_array_class_ptr) = 0;
+
+  virtual jvmtiError GetClassLoader(
+      jclass klass,
+      jobject* classloader_ptr) = 0;
+
+  virtual jvmtiError GetObjectHashCode(
+      jobject object,
+      jint* hash_code_ptr) = 0;
+
+  virtual jvmtiError GetObjectMonitorUsage(
+      jobject object,
+      jvmtiMonitorUsage* info_ptr) = 0;
+
+  virtual jvmtiError GetFieldName(
+      jclass klass,
+      jfieldID field,
+      char** name_ptr,
+      char** signature_ptr,
+      char** generic_ptr) = 0;
+
+  virtual jvmtiError GetFieldDeclaringClass(
+      jclass klass,
+      jfieldID field,
+      jclass* declaring_class_ptr) = 0;
+
+  virtual jvmtiError GetFieldModifiers(
+      jclass klass,
+      jfieldID field,
+      jint* modifiers_ptr) = 0;
+
+  virtual jvmtiError IsFieldSynthetic(
+      jclass klass,
+      jfieldID field,
+      jboolean* is_synthetic_ptr) = 0;
+
+  virtual jvmtiError GetMethodName(
+      jmethodID method,
+      char** name_ptr,
+      char** signature_ptr,
+      char** generic_ptr) = 0;
+
+  virtual jvmtiError GetMethodDeclaringClass(
+      jmethodID method,
+      jclass* declaring_class_ptr) = 0;
+
+  virtual jvmtiError GetMethodModifiers(
+      jmethodID method,
+      jint* modifiers_ptr) = 0;
+
+  virtual jvmtiError GetMaxLocals(
+      jmethodID method,
+      jint* max_ptr) = 0;
+
+  virtual jvmtiError GetArgumentsSize(
+      jmethodID method,
+      jint* size_ptr) = 0;
+
+  virtual jvmtiError GetLineNumberTable(
+      jmethodID method,
+      jint* entry_count_ptr,
+      jvmtiLineNumberEntry** table_ptr) = 0;
+
+  virtual jvmtiError GetMethodLocation(
+      jmethodID method,
+      jlocation* start_location_ptr,
+      jlocation* end_location_ptr) = 0;
+
+  virtual jvmtiError GetLocalVariableTable(
+      jmethodID method,
+      jint* entry_count_ptr,
+      jvmtiLocalVariableEntry** table_ptr) = 0;
+
+  virtual jvmtiError GetLoadedClasses(
+      jint* class_count_ptr,
+      jclass** classes_ptr) = 0;
+
+  virtual jvmtiError GetAllStackTraces(
+      jint max_frame_count,
+      jvmtiStackInfo** stack_info_ptr,
+      jint* thread_count_ptr) = 0;
+
+  virtual jvmtiError GetThreadListStackTraces(
+      jint thread_count,
+      const jthread* thread_list,
+      jint max_frame_count,
+      jvmtiStackInfo** stack_info_ptr) = 0;
+
+  virtual jvmtiError GetThreadLocalStorage(
+      jthread thread,
+      void** data_ptr) = 0;
+
+  virtual jvmtiError SetThreadLocalStorage(
+      jthread thread,
+      const void* data) = 0;
+
+  virtual jvmtiError GetStackTrace(
+      jthread thread,
+      jint start_depth,
+      jint max_frame_count,
+      jvmtiFrameInfo* frame_buffer,
+      jint* count_ptr) = 0;
+
+  virtual jvmtiError AddCapabilities(
+      const jvmtiCapabilities* capabilities_ptr) = 0;
+
+  virtual jvmtiError GetFrameLocation(
+      jthread thread,
+      jint depth,
+      jmethodID* method_ptr,
+      jlocation* location_ptr) = 0;
+
+  virtual jvmtiError GetErrorName(
+      jvmtiError error,
+      char** name_ptr) = 0;
+
+ private:
+  static jvmtiError JNICALL SetEventNotificationMode(
+      jvmtiEnv* env,
+      jvmtiEventMode mode,
+      jvmtiEvent event_type,
+      jthread event_thread,
+      ...) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->SetEventNotificationMode(mode, event_type, event_thread);
+  }
+
+  static jvmtiError JNICALL RunAgentThread(
+      jvmtiEnv* env,
+      jthread thread,
+      jvmtiStartFunction proc,
+      const void* arg,
+      jint priority) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->RunAgentThread(thread, proc, arg, priority);
+  }
+
+  static jvmtiError JNICALL GetLocalObject(
+      jvmtiEnv* env,
+      jthread thread,
+      jint depth,
+      jint slot,
+      jobject* value_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetLocalObject(thread, depth, slot, value_ptr);
+  }
+
+  static jvmtiError JNICALL GetLocalInt(
+      jvmtiEnv* env,
+      jthread thread,
+      jint depth,
+      jint slot,
+      jint* value_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetLocalInt(thread, depth, slot, value_ptr);
+  }
+
+  static jvmtiError JNICALL GetLocalLong(
+      jvmtiEnv* env,
+      jthread thread,
+      jint depth,
+      jint slot,
+      jlong* value_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetLocalLong(thread, depth, slot, value_ptr);
+  }
+
+  static jvmtiError JNICALL GetLocalFloat(
+      jvmtiEnv* env,
+      jthread thread,
+      jint depth,
+      jint slot,
+      jfloat* value_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetLocalFloat(thread, depth, slot, value_ptr);
+  }
+
+  static jvmtiError JNICALL GetLocalDouble(
+      jvmtiEnv* env,
+      jthread thread,
+      jint depth,
+      jint slot,
+      jdouble* value_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetLocalDouble(thread, depth, slot, value_ptr);
+  }
+
+  static jvmtiError JNICALL SetBreakpoint(
+      jvmtiEnv* env,
+      jmethodID method,
+      jlocation location) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->SetBreakpoint(method, location);
+  }
+
+  static jvmtiError JNICALL ClearBreakpoint(
+      jvmtiEnv* env,
+      jmethodID method,
+      jlocation location) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->ClearBreakpoint(method, location);
+  }
+
+  static jvmtiError JNICALL Deallocate(
+      jvmtiEnv* env,
+      unsigned char* mem) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->Deallocate(mem);
+  }
+
+  static jvmtiError JNICALL GetClassSignature(
+      jvmtiEnv* env,
+      jclass klass,
+      char** signature_ptr,
+      char** generic_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetClassSignature(klass, signature_ptr, generic_ptr);
+  }
+
+  static jvmtiError JNICALL GetClassStatus(
+      jvmtiEnv* env,
+      jclass klass,
+      jint* status_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetClassStatus(klass, status_ptr);
+  }
+
+  static jvmtiError JNICALL GetSourceFileName(
+      jvmtiEnv* env,
+      jclass klass,
+      char** source_name_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetSourceFileName(klass, source_name_ptr);
+  }
+
+  static jvmtiError JNICALL GetClassModifiers(
+      jvmtiEnv* env,
+      jclass klass,
+      jint* modifiers_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetClassModifiers(klass, modifiers_ptr);
+  }
+
+  static jvmtiError JNICALL GetClassMethods(
+      jvmtiEnv* env,
+      jclass klass,
+      jint* method_count_ptr,
+      jmethodID** methods_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetClassMethods(klass, method_count_ptr, methods_ptr);
+  }
+
+  static jvmtiError JNICALL GetClassFields(
+      jvmtiEnv* env,
+      jclass klass,
+      jint* field_count_ptr,
+      jfieldID** fields_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetClassFields(klass, field_count_ptr, fields_ptr);
+  }
+
+  static jvmtiError JNICALL GetImplementedInterfaces(
+      jvmtiEnv* env,
+      jclass klass,
+      jint* interface_count_ptr,
+      jclass** interfaces_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetImplementedInterfaces(
+        klass,
+        interface_count_ptr,
+        interfaces_ptr);
+  }
+
+  static jvmtiError JNICALL IsInterface(
+      jvmtiEnv* env,
+      jclass klass,
+      jboolean* is_interface_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->IsInterface(klass, is_interface_ptr);
+  }
+
+  static jvmtiError JNICALL IsArrayClass(
+      jvmtiEnv* env,
+      jclass klass,
+      jboolean* is_array_class_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->IsArrayClass(klass, is_array_class_ptr);
+  }
+
+  static jvmtiError JNICALL GetClassLoader(
+      jvmtiEnv* env,
+      jclass klass,
+      jobject* classloader_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetClassLoader(klass, classloader_ptr);
+  }
+
+  static jvmtiError JNICALL GetObjectHashCode(
+      jvmtiEnv* env,
+      jobject object,
+      jint* hash_code_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetObjectHashCode(object, hash_code_ptr);
+  }
+
+  static jvmtiError JNICALL GetObjectMonitorUsage(
+      jvmtiEnv* env,
+      jobject object,
+      jvmtiMonitorUsage* info_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetObjectMonitorUsage(object, info_ptr);
+  }
+
+  static jvmtiError JNICALL GetFieldName(
+      jvmtiEnv* env,
+      jclass klass,
+      jfieldID field,
+      char** name_ptr,
+      char** signature_ptr,
+      char** generic_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetFieldName(klass, field, name_ptr, signature_ptr, generic_ptr);
+  }
+
+  static jvmtiError JNICALL GetFieldDeclaringClass(
+      jvmtiEnv* env,
+      jclass klass,
+      jfieldID field,
+      jclass* declaring_class_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetFieldDeclaringClass(klass, field, declaring_class_ptr);
+  }
+
+  static jvmtiError JNICALL GetFieldModifiers(
+      jvmtiEnv* env,
+      jclass klass,
+      jfieldID field,
+      jint* modifiers_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetFieldModifiers(klass, field, modifiers_ptr);
+  }
+
+  static jvmtiError JNICALL IsFieldSynthetic(
+      jvmtiEnv* env,
+      jclass klass,
+      jfieldID field,
+      jboolean* is_synthetic_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->IsFieldSynthetic(klass, field, is_synthetic_ptr);
+  }
+
+  static jvmtiError JNICALL GetMethodName(
+      jvmtiEnv* env,
+      jmethodID method,
+      char** name_ptr,
+      char** signature_ptr,
+      char** generic_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetMethodName(method, name_ptr, signature_ptr, generic_ptr);
+  }
+
+  static jvmtiError JNICALL GetMethodDeclaringClass(
+      jvmtiEnv* env,
+      jmethodID method,
+      jclass* declaring_class_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetMethodDeclaringClass(method, declaring_class_ptr);
+  }
+
+  static jvmtiError JNICALL GetMethodModifiers(
+      jvmtiEnv* env,
+      jmethodID method,
+      jint* modifiers_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetMethodModifiers(method, modifiers_ptr);
+  }
+
+  static jvmtiError JNICALL GetMaxLocals(
+      jvmtiEnv* env,
+      jmethodID method,
+      jint* max_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetMaxLocals(method, max_ptr);
+  }
+
+  static jvmtiError JNICALL GetArgumentsSize(
+      jvmtiEnv* env,
+      jmethodID method,
+      jint* size_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetArgumentsSize(method, size_ptr);
+  }
+
+  static jvmtiError JNICALL GetLineNumberTable(
+      jvmtiEnv* env,
+      jmethodID method,
+      jint* entry_count_ptr,
+      jvmtiLineNumberEntry** table_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetLineNumberTable(method, entry_count_ptr, table_ptr);
+  }
+
+  static jvmtiError JNICALL GetMethodLocation(
+      jvmtiEnv* env,
+      jmethodID method,
+      jlocation* start_location_ptr,
+      jlocation* end_location_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetMethodLocation(method, start_location_ptr, end_location_ptr);
+  }
+
+  static jvmtiError JNICALL GetLocalVariableTable(
+      jvmtiEnv* env,
+      jmethodID method,
+      jint* entry_count_ptr,
+      jvmtiLocalVariableEntry** table_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetLocalVariableTable(method, entry_count_ptr, table_ptr);
+  }
+
+  static jvmtiError JNICALL GetLoadedClasses(
+      jvmtiEnv* env,
+      jint* class_count_ptr,
+      jclass** classes_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetLoadedClasses(class_count_ptr, classes_ptr);
+  }
+
+  static jvmtiError JNICALL GetAllStackTraces(
+      jvmtiEnv* env,
+      jint max_frame_count,
+      jvmtiStackInfo** stack_info_ptr,
+      jint* thread_count_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetAllStackTraces(
+        max_frame_count,
+        stack_info_ptr,
+        thread_count_ptr);
+  }
+
+  static jvmtiError JNICALL GetThreadListStackTraces(
+      jvmtiEnv* env,
+      jint thread_count,
+      const jthread* thread_list,
+      jint max_frame_count,
+      jvmtiStackInfo** stack_info_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetThreadListStackTraces(
+        thread_count,
+        thread_list,
+        max_frame_count,
+        stack_info_ptr);
+  }
+
+  static jvmtiError JNICALL GetThreadLocalStorage(
+      jvmtiEnv* env,
+      jthread thread,
+      void** data_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetThreadLocalStorage(thread, data_ptr);
+  }
+
+  static jvmtiError JNICALL SetThreadLocalStorage(
+      jvmtiEnv* env,
+      jthread thread,
+      const void* data) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->SetThreadLocalStorage(thread, data);
+  }
+
+  static jvmtiError JNICALL GetStackTrace(
+      jvmtiEnv* env,
+      jthread thread,
+      jint start_depth,
+      jint max_frame_count,
+      jvmtiFrameInfo* frame_buffer,
+      jint* count_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetStackTrace(
+        thread,
+        start_depth,
+        max_frame_count,
+        frame_buffer,
+        count_ptr);
+  }
+
+  static jvmtiError JNICALL AddCapabilities(
+      jvmtiEnv* env,
+      const jvmtiCapabilities* capabilities_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->AddCapabilities(capabilities_ptr);
+  }
+
+  static jvmtiError JNICALL GetFrameLocation(
+      jvmtiEnv* env,
+      jthread thread,
+      jint depth,
+      jmethodID* method_ptr,
+      jlocation* location_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetFrameLocation(thread, depth, method_ptr, location_ptr);
+  }
+
+  static jvmtiError JNICALL GetErrorName(
+      jvmtiEnv* env,
+      jvmtiError error,
+      char** name_ptr) {
+    MockableJvmtiEnv* p = static_cast<MockableJvmtiEnv*>(env);
+    return p->GetErrorName(error, name_ptr);
+  }
+
+ private:
+  jvmtiInterface_1_ functions_;
+};
+
+
+class MockJvmtiEnv : public MockableJvmtiEnv {
+ public:
+  MOCK_METHOD(jvmtiError, SetEventNotificationMode,
+              (jvmtiEventMode, jvmtiEvent, jthread), (override));
+
+  MOCK_METHOD(jvmtiError, RunAgentThread,
+              (jthread, jvmtiStartFunction, const void* arg, jint), (override));
+
+  MOCK_METHOD(jvmtiError, GetLocalObject, (jthread, jint, jint, jobject*),
+              (override));
+
+  MOCK_METHOD(jvmtiError, GetLocalInt, (jthread, jint, jint, jint*),
+              (override));
+
+  MOCK_METHOD(jvmtiError, GetLocalLong, (jthread, jint, jint, jlong*),
+              (override));
+
+  MOCK_METHOD(jvmtiError, GetLocalFloat, (jthread, jint, jint, jfloat*),
+              (override));
+
+  MOCK_METHOD(jvmtiError, GetLocalDouble, (jthread, jint, jint, jdouble*),
+              (override));
+
+  MOCK_METHOD(jvmtiError, SetBreakpoint, (jmethodID, jlocation), (override));
+
+  MOCK_METHOD(jvmtiError, ClearBreakpoint, (jmethodID, jlocation), (override));
+
+  MOCK_METHOD(jvmtiError, Deallocate, (unsigned char*), (override));
+
+  MOCK_METHOD(jvmtiError, GetClassSignature, (jclass, char**, char**),
+              (override));
+
+  MOCK_METHOD(jvmtiError, GetClassStatus, (jclass, jint*), (override));
+
+  MOCK_METHOD(jvmtiError, GetSourceFileName, (jclass, char**), (override));
+
+  MOCK_METHOD(jvmtiError, GetClassModifiers, (jclass, jint*), (override));
+
+  MOCK_METHOD(jvmtiError, GetClassMethods, (jclass, jint*, jmethodID**),
+              (override));
+
+  MOCK_METHOD(jvmtiError, GetClassFields, (jclass, jint*, jfieldID**),
+              (override));
+
+  MOCK_METHOD(jvmtiError, GetImplementedInterfaces, (jclass, jint*, jclass**),
+              (override));
+
+  MOCK_METHOD(jvmtiError, IsInterface, (jclass, jboolean*), (override));
+
+  MOCK_METHOD(jvmtiError, IsArrayClass, (jclass, jboolean*), (override));
+
+  MOCK_METHOD(jvmtiError, GetClassLoader, (jclass, jobject*), (override));
+
+  MOCK_METHOD(jvmtiError, GetObjectHashCode, (jobject, jint*), (override));
+
+  MOCK_METHOD(jvmtiError, GetObjectMonitorUsage, (jobject, jvmtiMonitorUsage*),
+              (override));
+
+  MOCK_METHOD(jvmtiError, GetFieldName,
+              (jclass, jfieldID, char**, char**, char**), (override));
+
+  MOCK_METHOD(jvmtiError, GetFieldDeclaringClass, (jclass, jfieldID, jclass*),
+              (override));
+
+  MOCK_METHOD(jvmtiError, GetFieldModifiers, (jclass, jfieldID, jint*),
+              (override));
+
+  MOCK_METHOD(jvmtiError, IsFieldSynthetic, (jclass, jfieldID, jboolean*),
+              (override));
+
+  MOCK_METHOD(jvmtiError, GetMethodName, (jmethodID, char**, char**, char**),
+              (override));
+
+  MOCK_METHOD(jvmtiError, GetMethodDeclaringClass, (jmethodID, jclass*),
+              (override));
+
+  MOCK_METHOD(jvmtiError, GetMethodModifiers, (jmethodID, jint*), (override));
+
+  MOCK_METHOD(jvmtiError, GetMaxLocals, (jmethodID, jint*), (override));
+
+  MOCK_METHOD(jvmtiError, GetArgumentsSize, (jmethodID, jint*), (override));
+
+  MOCK_METHOD(jvmtiError, GetLineNumberTable,
+              (jmethodID, jint*, jvmtiLineNumberEntry**), (override));
+
+  MOCK_METHOD(jvmtiError, GetMethodLocation,
+              (jmethodID, jlocation*, jlocation*), (override));
+
+  MOCK_METHOD(jvmtiError, GetLocalVariableTable,
+              (jmethodID, jint*, jvmtiLocalVariableEntry**), (override));
+
+  MOCK_METHOD(jvmtiError, GetLoadedClasses, (jint*, jclass**), (override));
+
+  MOCK_METHOD(jvmtiError, GetAllStackTraces, (jint, jvmtiStackInfo**, jint*),
+              (override));
+
+  MOCK_METHOD(jvmtiError, GetThreadListStackTraces,
+              (jint, const jthread*, jint, jvmtiStackInfo**), (override));
+
+  MOCK_METHOD(jvmtiError, GetThreadLocalStorage, (jthread, void**), (override));
+
+  MOCK_METHOD(jvmtiError, SetThreadLocalStorage, (jthread, const void*),
+              (override));
+
+  MOCK_METHOD(jvmtiError, GetStackTrace,
+              (jthread, jint, jint, jvmtiFrameInfo*, jint*), (override));
+
+  MOCK_METHOD(jvmtiError, AddCapabilities, (const jvmtiCapabilities*),
+              (override));
+
+  MOCK_METHOD(jvmtiError, GetFrameLocation,
+              (jthread, jint, jmethodID*, jlocation*), (override));
+
+  MOCK_METHOD(jvmtiError, GetErrorName, (jvmtiError, char**), (override));
+};
+
+
+class GlobalJvmEnv {
+ public:
+  GlobalJvmEnv(jvmtiEnv* jvmti, JNIEnv* jni);
+  ~GlobalJvmEnv();
+};
+
+
+// Helper class to temporarily set global "JNIEnv*" to nullptr.
+class GlobalNoJni {
+ public:
+  GlobalNoJni();
+  ~GlobalNoJni();
+
+ private:
+  JNIEnv* const original_jni_;
+};
+
+}  // namespace cdbg
+}  // namespace devtools
+
+#endif  // DEVTOOLS_CDBG_DEBUGLETS_JAVA_MOCK_JVMTI_ENV_H_

--- a/src/codegen/BUILD
+++ b/src/codegen/BUILD
@@ -1,0 +1,67 @@
+package(default_visibility = ["//visibility:public"])
+
+ALL_GENERATED_CLASSES = [
+    "api_client_datetime",
+    "arithmeticexception",
+    "bigdecimal",
+    "biginteger",
+    "breakpointlabelsprovider",
+    "classcastexception",
+    "class",
+    "classloader",
+    "classpathlookup",
+    "exception",
+    "firebaseclient",
+    "gcpbreakpointlabelsprovider",
+    "gcpdebugletversion",
+    "gcphubclient",
+    "hubclient",
+    "hubclient_listactivebreakpointsresult",
+    "iterable",
+    "ju_hashmap",
+    "jul_logger",
+    "ju_map",
+    "ju_map_entry",
+    "negativearraysizeexception",
+    "nullpointerexception",
+    "object",
+    "printwriter",
+    "statistician",
+    "string",
+    "stringwriter",
+    "thread",
+    "throwable",
+    "useridprovider",
+    "yamlconfigparser",
+]
+
+genrule(
+    name = "jni_proxy_code_gen_cc",
+    srcs = [
+        "config.json",
+    ],
+    outs = ["generated/jni_proxy_%s.cc" % c for c in ALL_GENERATED_CLASSES],
+    cmd = "$(location //src/codegen/src/main/java/devtools/cdbg/debuglets/java/codegen:jni_proxy_code_gen_tool) $(location config.json) $(@D)/generated",
+    tools = ["//src/codegen/src/main/java/devtools/cdbg/debuglets/java/codegen:jni_proxy_code_gen_tool"],
+)
+
+genrule(
+    name = "jni_proxy_code_gen_h",
+    srcs = [
+        "config.json",
+    ],
+    outs = ["generated/jni_proxy_%s.h" % c for c in ALL_GENERATED_CLASSES],
+    cmd = "$(location //src/codegen/src/main/java/devtools/cdbg/debuglets/java/codegen:jni_proxy_code_gen_tool) $(location config.json) $(@D)/generated",
+    tools = ["//src/codegen/src/main/java/devtools/cdbg/debuglets/java/codegen:jni_proxy_code_gen_tool"],
+)
+
+cc_library(
+    name = "jni_proxies",
+    srcs = [":jni_proxy_code_gen_cc"],
+    hdrs = [":jni_proxy_code_gen_h"],
+    copts = ["-Isrc/agent"],
+    deps = [
+        "//src/agent:common",
+        "//src/agent:jni_utils_h",
+    ],
+)

--- a/src/codegen/src/main/java/devtools/cdbg/debuglets/java/codegen/BUILD
+++ b/src/codegen/src/main/java/devtools/cdbg/debuglets/java/codegen/BUILD
@@ -1,0 +1,25 @@
+package(default_visibility = ["//visibility:public"])
+
+java_library(
+    name = "jni_proxy_code_gen_lib",
+    srcs = [
+        "Config.java",
+        "JniProxyCodeGen.java",
+    ],
+    resources = glob(["*.tpl"]),
+    deps = [
+        "@maven//:com_google_guava_guava",
+        "@maven//:org_ow2_asm_asm",
+        "@maven//:org_freemarker_freemarker",
+        "@maven//:com_google_code_gson_gson",
+    ],
+)
+
+java_binary(
+    name = "jni_proxy_code_gen_tool",
+    main_class = "devtools.cdbg.debuglets.java.codegen.JniProxyCodeGen",
+    runtime_deps = [
+        ":jni_proxy_code_gen_lib",
+        "//src/agent/internals/src/main/java/com/google/devtools/cdbg/debuglets/java:cdbg_java_agent_internals",
+    ],
+)


### PR DESCRIPTION
Adding this unit test also adds build rules for the generated jni_proxy code and adds in MockJNIEnv, which are dependencies for many of the unit tests and so paves the way for adding them as well.