### PR TITLE
chore: Build fix.

### DIFF
--- a/src/agent/Makefile
+++ b/src/agent/Makefile
@@ -161,7 +161,7 @@ JNI_PROXIES_GENERATED_OBJECTS = \
 	jni_proxy_*.o \
 
 SOURCES := \
-	$(filter-out %_test.cc, $(wildcard *.cc)) \
+	$(filter-out %_test.cc mock_% fake_%, $(wildcard *.cc)) \
 	$(ANTLR_JAVA_EXPRESSION_GENERATED_SOURCES) \
 	$(ANTLR_RUNTIME_SOURCES) \
 


### PR DESCRIPTION
The recent addition of mock_ and fake_ files for testing broke the main agent build.