### PR TITLE
chore: Add another batch of unit tests

### DIFF
--- a/src/agent/BUILD
+++ b/src/agent/BUILD
@@ -299,30 +299,6 @@ cc_library(
 )
 
 cc_library(
-    name = "type_evaluator",
-    hdrs = ["type_evaluator.h"],
-    deps = [
-        ":class_metadata_reader",
-        ":common",
-        ":method_caller",
-    ],
-)
-
-cc_library(
-    name = "generic_type_evaluator",
-    srcs = ["generic_type_evaluator.cc"],
-    hdrs = ["generic_type_evaluator.h"],
-    deps = [
-        ":common",
-        ":instance_field_reader",
-        ":jvariant",
-        ":messages",
-        ":model",
-        ":type_evaluator",
-    ],
-)
-
-cc_library(
     name = "callbacks_monitor",
     srcs = ["callbacks_monitor.cc"],
     hdrs = ["callbacks_monitor.h"],
@@ -360,7 +336,10 @@ cc_library(
     name = "statistician",
     srcs = ["statistician.cc"],
     hdrs = ["statistician.h"],
-    copts = ["-Isrc/agent", "-I$(BINDIR)/src/codegen/generated"],
+    copts = [
+        "-Isrc/agent",
+        "-I$(BINDIR)/src/codegen/generated"
+    ],
     deps = [
         ":common",
         ":mutex",
@@ -430,6 +409,30 @@ cc_library(
 )
 
 cc_library(
+    name = "type_evaluator",
+    hdrs = ["type_evaluator.h"],
+    deps = [
+        ":class_metadata_reader",
+        ":common",
+        ":method_caller",
+    ],
+)
+
+cc_library(
+    name = "generic_type_evaluator",
+    srcs = ["generic_type_evaluator.cc"],
+    hdrs = ["generic_type_evaluator.h"],
+    deps = [
+        ":common",
+        ":instance_field_reader",
+        ":jvariant",
+        ":messages",
+        ":model",
+        ":type_evaluator",
+    ],
+)
+
+cc_library(
     name = "array_type_evaluator",
     hdrs = ["array_type_evaluator.h"],
     deps = [
@@ -447,6 +450,106 @@ cc_library(
     hdrs = ["object_evaluator.h"],
     deps = [
         ":common",
+    ],
+)
+
+cc_library(
+    name = "jvm_object_evaluator",
+    srcs = ["jvm_object_evaluator.cc"],
+    hdrs = ["jvm_object_evaluator.h"],
+    deps = [
+        ":array_type_evaluator",
+        ":class_indexer",
+        ":class_metadata_reader",
+        ":common",
+        ":config",
+        ":generic_type_evaluator",
+        ":iterable_type_evaluator",
+        ":jvariant",
+        ":map_entry_type_evaluator",
+        ":map_type_evaluator",
+        ":messages",
+        ":model",
+        ":object_evaluator",
+        ":safe_method_caller",
+        ":stringable_type_evaluator",
+        ":type_evaluator",
+        ":value_formatter",
+    ],
+)
+
+cc_library(
+    name = "iterable_type_evaluator",
+    srcs = ["iterable_type_evaluator.cc"],
+    hdrs = ["iterable_type_evaluator.h"],
+    copts = [
+        "-Isrc/agent",
+        "-I$(BINDIR)/src/codegen/generated"
+    ],
+    deps = [
+        ":common",
+        ":jni_utils",
+        ":messages",
+        ":model",
+        ":model_util",
+        ":type_evaluator",
+        "//src/codegen:jni_proxies",
+    ],
+)
+
+cc_library(
+    name = "map_entry_type_evaluator",
+    srcs = ["map_entry_type_evaluator.cc"],
+    hdrs = ["map_entry_type_evaluator.h"],
+    copts = [
+        "-Isrc/agent",
+        "-I$(BINDIR)/src/codegen/generated"
+    ],
+    deps = [
+        ":common",
+        ":jni_utils",
+        ":jvmti_buffer",
+        ":messages",
+        ":model",
+        ":model_util",
+        ":type_evaluator",
+        "//src/codegen:jni_proxies",
+    ],
+)
+
+cc_library(
+    name = "map_type_evaluator",
+    srcs = ["map_type_evaluator.cc"],
+    hdrs = ["map_type_evaluator.h"],
+    copts = [
+        "-Isrc/agent",
+        "-I$(BINDIR)/src/codegen/generated"
+    ],
+    deps = [
+        ":common",
+        ":iterable_type_evaluator",
+        ":jni_utils",
+        ":map_entry_type_evaluator",
+        ":messages",
+        ":model",
+        ":model_util",
+        ":type_evaluator",
+        ":value_formatter",
+        "//src/codegen:jni_proxies",
+    ],
+)
+
+cc_library(
+    name = "stringable_type_evaluator",
+    srcs = ["stringable_type_evaluator.cc"],
+    hdrs = ["stringable_type_evaluator.h"],
+    copts = [
+        "-Isrc/agent",
+        "-I$(BINDIR)/src/codegen/generated"
+    ],
+    deps = [
+        ":type_evaluator",
+        "//src/codegen:jni_proxies",
     ],
 )
 

--- a/src/agent/BUILD
+++ b/src/agent/BUILD
@@ -194,12 +194,54 @@ cc_library(
 )
 
 cc_library(
+    name = "generic_type_evaluator",
+    srcs = ["generic_type_evaluator.cc"],
+    hdrs = ["generic_type_evaluator.h"],
+    deps = [
+        ":common",
+        ":instance_field_reader",
+        ":jvariant",
+        ":messages",
+        ":model",
+        ":type_evaluator",
+    ],
+)
+
+cc_library(
     name = "callbacks_monitor",
     srcs = ["callbacks_monitor.cc"],
     hdrs = ["callbacks_monitor.h"],
     deps = [
         ":common",
     ],
+)
+
+cc_library(
+    name = "format_queue",
+    srcs = ["format_queue.cc"],
+    hdrs = ["format_queue.h"],
+    deps = [
+        ":capture_data_collector",
+        ":common",
+        ":model",
+        ":mutex",
+        ":observable",
+        ":statistician",
+    ],
+)
+
+cc_library(
+    name = "statistician",
+    srcs = ["statistician.cc"],
+    hdrs = ["statistician.h"],
+    copts = ["-Isrc/agent", "-I$(BINDIR)/src/codegen/generated"],
+    deps = [
+        ":common",
+        ":mutex",
+        ":stopwatch",
+        "//src/codegen:jni_proxies",
+    ],
+    alwayslink = 1,
 )
 
 cc_library(
@@ -349,6 +391,25 @@ cc_library(
 )
 
 cc_library(
+    name = "glob_data_visibility_policy",
+    srcs = ["glob_data_visibility_policy.cc"],
+    hdrs = ["glob_data_visibility_policy.h"],
+    deps = [
+        ":data_visibility_policy",
+        ":type_util",
+    ],
+)
+
+cc_library(
+    name = "multi_data_visibility_policy",
+    srcs = ["multi_data_visibility_policy.cc"],
+    hdrs = ["multi_data_visibility_policy.h"],
+    deps = [
+        ":data_visibility_policy",
+    ],
+)
+
+cc_library(
     name = "class_indexer",
     hdrs = ["class_indexer.h"],
     deps = [
@@ -436,6 +497,43 @@ cc_library(
     deps = [
         ":common",
         ":model",
+    ],
+)
+
+cc_library(
+    name = "jvm_breakpoint",
+    srcs = ["jvm_breakpoint.cc"],
+    hdrs = ["jvm_breakpoint.h"],
+    deps = [
+        ":auto_jvmti_breakpoint",
+        ":breakpoint",
+        ":breakpoints_manager",
+        ":capture_data_collector",
+        ":class_indexer",
+        ":class_path_lookup",
+        ":common",
+        ":dynamic_logger",
+        ":expression_evaluator_h",
+        ":expression_util_h",
+        ":format_queue",
+        ":java_expression_evaluator",
+        ":jni_utils",
+        ":jni_utils_h",
+        ":jvm_evaluators",
+        ":jvm_readers_factory",
+        ":jvmti_buffer",
+        ":leaky_bucket",
+        ":log_data_collector",
+        ":messages",
+        ":model",
+        ":model_util",
+        ":mutex",
+        ":rate_limit",
+        ":resolved_source_location",
+        ":scheduler",
+        ":statistician",
+        ":stopwatch",
+        ":type_util",
     ],
 )
 
@@ -669,15 +767,6 @@ cc_library(
         ":common",
         ":config",
         ":safe_caller_proxies",
-    ],
-)
-
-cc_library(
-    name = "multi_data_visibility_policy",
-    srcs = ["multi_data_visibility_policy.cc"],
-    hdrs = ["multi_data_visibility_policy.h"],
-    deps = [
-        ":data_visibility_policy",
     ],
 )
 

--- a/src/agent/BUILD
+++ b/src/agent/BUILD
@@ -105,6 +105,14 @@ cc_library(
 )
 
 cc_library(
+    name = "resolved_source_location",
+    hdrs = ["resolved_source_location.h"],
+    deps = [
+        ":model",
+    ],
+)
+
+cc_library(
     name = "value_formatter",
     srcs = ["value_formatter.cc"],
     hdrs = ["value_formatter.h"],
@@ -159,6 +167,38 @@ cc_library(
 )
 
 cc_library(
+    name = "jvm_object_array_reader",
+    hdrs = ["jvm_object_array_reader.h"],
+    deps = [
+        ":array_reader",
+        ":common",
+        ":jni_utils",
+        ":jni_utils_h",
+        ":jvariant",
+        ":messages",
+        ":method_call_result",
+        ":model",
+        ":model_util",
+    ],
+)
+
+cc_library(
+    name = "jvm_primitive_array_reader",
+    hdrs = ["jvm_primitive_array_reader.h"],
+    deps = [
+        ":array_reader",
+        ":common",
+        ":jni_utils",
+        ":jni_utils_h",
+        ":jvariant",
+        ":messages",
+        ":method_call_result",
+        ":model",
+        ":model_util",
+    ],
+)
+
+cc_library(
     name = "method_locals",
     srcs = ["method_locals.cc"],
     hdrs = ["method_locals.h"],
@@ -180,6 +220,33 @@ cc_library(
         ":class_metadata_reader",
         ":common",
         ":method_caller",
+    ],
+)
+
+cc_library(
+    name = "jvm_readers_factory",
+    srcs = ["jvm_readers_factory.cc"],
+    hdrs = ["jvm_readers_factory.h"],
+    deps = [
+        ":class_indexer",
+        ":class_metadata_reader",
+        ":class_path_lookup",
+        ":common",
+        ":instance_field_reader",
+        ":jni_utils",
+        ":jni_utils_h",
+        ":jvm_evaluators",
+        ":jvm_object_array_reader",
+        ":jvm_primitive_array_reader",
+        ":jvmti_buffer",
+        ":local_variable_reader",
+        ":messages",
+        ":method_locals",
+        ":model",
+        ":readers_factory",
+        ":safe_method_caller",
+        ":static_field_reader",
+        ":type_util",
     ],
 )
 
@@ -227,6 +294,17 @@ cc_library(
         ":mutex",
         ":observable",
         ":statistician",
+    ],
+)
+
+cc_library(
+    name = "class_path_lookup",
+    hdrs = ["class_path_lookup.h"],
+    deps = [
+        ":common",
+        ":jni_utils",
+        ":jni_utils_h",
+        ":jvariant",
     ],
 )
 
@@ -347,6 +425,17 @@ cc_library(
     hdrs = ["scheduler.h"],
     deps = [
         ":common",
+        ":mutex",
+    ],
+)
+
+cc_library(
+    name = "rate_limit",
+    srcs = ["rate_limit.cc"],
+    hdrs = ["rate_limit.h"],
+    deps = [
+        ":common",
+        ":leaky_bucket",
         ":mutex",
     ],
 )
@@ -543,6 +632,30 @@ cc_library(
     deps = [
         ":common",
         ":leaky_bucket",
+    ],
+)
+
+cc_library(
+    name = "jvm_breakpoints_manager",
+    srcs = ["jvm_breakpoints_manager.cc"],
+    hdrs = ["jvm_breakpoints_manager.h"],
+    copts = [
+        "-Isrc/agent",
+        "-I$(BINDIR)/src/codegen/generated",
+    ],
+    deps = [
+        ":breakpoint",
+        ":breakpoints_manager",
+        ":callbacks_monitor",
+        ":canary_control",
+        ":class_indexer",
+        ":common",
+        ":format_queue",
+        ":jvm_evaluators",
+        ":leaky_bucket",
+        ":mutex",
+        ":rate_limit",
+        ":statistician",
     ],
 )
 
@@ -954,3 +1067,35 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "dynamic_logger",
+    hdrs = ["dynamic_logger.h"],
+    deps = [
+        ":common",
+        ":model",
+    ],
+)
+
+cc_library(
+    name = "log_data_collector",
+    srcs = ["log_data_collector.cc"],
+    hdrs = ["log_data_collector.h"],
+    copts = [
+        "-Isrc/agent",
+        "-I$(BINDIR)/src/codegen/generated",
+    ],
+    deps = [
+        ":class_indexer",
+        ":common",
+        ":expression_evaluator_h",
+        ":expression_util_h",
+        ":messages",
+        ":method_caller",
+        ":model",
+        ":object_evaluator",
+        ":readers_factory",
+        ":type_util",
+        ":value_formatter",
+        "//src/codegen:jni_proxies",
+    ],
+)

--- a/src/agent/BUILD
+++ b/src/agent/BUILD
@@ -251,6 +251,54 @@ cc_library(
 )
 
 cc_library(
+    name = "jvm_class_metadata_reader",
+    srcs = ["jvm_class_metadata_reader.cc"],
+    hdrs = ["jvm_class_metadata_reader.h"],
+    copts = [
+        "-Isrc/agent",
+        "-I$(BINDIR)/src/codegen/generated",
+    ],
+    deps = [
+        ":class_metadata_reader",
+        ":common",
+        ":data_visibility_policy",
+        ":jni_utils",
+        ":jni_utils_h",
+        ":jobject_map",
+        ":jvariant",
+        ":jvm_instance_field_reader",
+        ":jvm_static_field_reader",
+        ":jvmti_buffer",
+        ":mutex",
+        "//src/codegen:jni_proxies",
+    ],
+)
+
+cc_library(
+    name = "jvm_instance_field_reader",
+    srcs = ["jvm_instance_field_reader.cc"],
+    hdrs = ["jvm_instance_field_reader.h"],
+    deps = [
+        ":common",
+        ":instance_field_reader",
+        ":jvariant",
+        ":messages",
+    ],
+)
+
+cc_library(
+    name = "jvm_static_field_reader",
+    srcs = ["jvm_static_field_reader.cc"],
+    hdrs = ["jvm_static_field_reader.h"],
+    deps = [
+        ":common",
+        ":jvariant",
+        ":messages",
+        ":static_field_reader",
+    ],
+)
+
+cc_library(
     name = "type_evaluator",
     hdrs = ["type_evaluator.h"],
     deps = [
@@ -508,6 +556,18 @@ cc_library(
         ":jvariant",
         ":observable",
         ":type_util",
+    ],
+)
+
+cc_library(
+    name = "structured_data_visibility_policy",
+    srcs = ["structured_data_visibility_policy.cc"],
+    hdrs = ["structured_data_visibility_policy.h"],
+    deps = [
+        ":common",
+        ":data_visibility_policy",
+        ":jni_utils",
+        ":jni_utils_h",
     ],
 )
 

--- a/tests/agent/BUILD
+++ b/tests/agent/BUILD
@@ -439,6 +439,26 @@ cc_test(
 )
 
 cc_test(
+    name = "jvm_class_metadata_reader_test",
+    srcs = ["jvm_class_metadata_reader_test.cc"],
+    copts = [
+        "-Isrc/agent",
+        "-I$(BINDIR)/src/codegen/generated",
+    ],
+    deps = [
+        ":mock_jni_env",
+        ":mock_jvmti_env",
+        "//src/agent:glob_data_visibility_policy",
+        "//src/agent:instance_field_reader",
+        "//src/agent:jvm_class_metadata_reader",
+        "//src/agent:static_field_reader",
+        "//src/agent:structured_data_visibility_policy",
+        "//src/codegen:mock_jni_proxies",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "jvm_eval_call_stack_test",
     srcs = ["jvm_eval_call_stack_test.cc"],
     deps = [

--- a/tests/agent/BUILD
+++ b/tests/agent/BUILD
@@ -605,6 +605,26 @@ cc_test(
 )
 
 jvm_test(
+    name = "model_json_test",
+    srcs = ["model_json_test.cc"],
+    cc_deps = [
+        ":fake_jni",
+        ":mock_jvmti_env",
+        "//src/agent:model_json",
+        "//src/agent:model_util",
+        "//src/codegen:jni_proxies",
+        "@com_google_googletest//:gtest",
+    ],
+    copts = [
+        "-Isrc/agent",
+        "-I$(BINDIR)/src/codegen/generated",
+    ],
+    java_deps = [
+        "@maven//:com_google_api_client_google_api_client",
+    ],
+)
+
+jvm_test(
     name = "model_util_test",
     srcs = ["model_util_test.cc"],
     cc_deps = [

--- a/tests/agent/BUILD
+++ b/tests/agent/BUILD
@@ -565,6 +565,30 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "log_data_collector_test",
+    srcs = ["log_data_collector_test.cc"],
+    copts = [
+        "-Isrc/agent",
+        "-I$(BINDIR)/src/codegen/generated",
+    ],
+    deps = [
+        ":fake_jni",
+        ":mock_jvmti_env",
+        ":mock_method_caller",
+        ":mock_object_evaluator",
+        ":mock_readers_factory",
+        "//src/agent:model_json",
+        "//src/agent:model_util",
+        "//src/agent:config_builder",
+        "//src/agent:expression_evaluator_h",
+        "//src/agent:java_expression_evaluator",
+        "//src/agent:log_data_collector",
+        "//src/codegen:mock_jni_proxies",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 jvm_test(
     name = "model_util_test",
     srcs = ["model_util_test.cc"],

--- a/tests/agent/BUILD
+++ b/tests/agent/BUILD
@@ -509,6 +509,34 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "jvm_object_evaluator_test",
+    srcs = ["jvm_object_evaluator_test.cc"],
+    copts = [
+        "-Isrc/agent",
+        "-I$(BINDIR)/src/codegen/generated",
+    ],
+    deps = [
+        ":fake_instance_field_reader",
+        ":fake_jni",
+        ":mock_class_indexer",
+        ":mock_class_metadata_reader",
+        ":mock_jvmti_env",
+        ":mock_method_caller",
+        "//src/agent:config_builder",
+        "//src/agent:instance_field_reader",
+        "//src/agent:jni_utils",
+        "//src/agent:jni_utils_h",
+        "//src/agent:jvm_object_evaluator",
+        "//src/agent:messages",
+        "//src/agent:model",
+        "//src/agent:static_field_reader",
+        "//src/agent:type_evaluator",
+        "//src/codegen:jni_proxies",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 jvm_test(
     name = "model_util_test",
     srcs = ["model_util_test.cc"],

--- a/tests/agent/BUILD
+++ b/tests/agent/BUILD
@@ -358,40 +358,72 @@ cc_test(
     ],
 )
 
-#cc_test(
-#    name = "jvm_breakpoint_test",
-#    srcs = ["jvm_breakpoint_test.cc"],
-#    deps = [
-#        ":fake_jni",
-#        ":json_eq_matcher",
-#        ":mock_breakpoint_labels_provider",
-#        ":mock_breakpoints_manager",
-#        ":mock_class_indexer",
-#        ":mock_class_metadata_reader",
-#        ":mock_class_path_lookup",
-#        ":mock_dynamic_logger",
-#        ":mock_eval_call_stack",
-#        ":mock_jvmti_env",
-#        ":mock_object_evaluator",
-#        ":mock_user_id_provider",
-#        "//src/agent:class_metadata_reader",
-#        "//src/agent:config_builder",
-#        "//src/agent:format_queue",
-#        "//src/agent:instance_field_reader",
-#        "//src/agent:jni_utils_h",
-#        "//src/agent:jvm_breakpoint",
-#        "//src/agent:jvm_evaluators",
-#        "//src/agent:messages",
-#        "//src/agent:method_locals",
-#        "//src/agent:model_json",
-#        "//src/agent:model_util",
-#        "//src/agent:object_evaluator",
-#        "//src/agent:resolved_source_location",
-#        "//src/agent:static_field_reader",
-#        "//src/agent:statistician",
-#        "@com_google_googletest//:gtest_main",
-#    ],
-#)
+cc_test(
+    name = "jvm_breakpoint_test",
+    srcs = ["jvm_breakpoint_test.cc"],
+    deps = [
+        ":fake_jni",
+        ":json_eq_matcher",
+        ":mock_breakpoint_labels_provider",
+        ":mock_breakpoints_manager",
+        ":mock_class_indexer",
+        ":mock_class_metadata_reader",
+        ":mock_class_path_lookup",
+        ":mock_dynamic_logger",
+        ":mock_eval_call_stack",
+        ":mock_jvmti_env",
+        ":mock_object_evaluator",
+        ":mock_user_id_provider",
+        "//src/agent:class_metadata_reader",
+        "//src/agent:config_builder",
+        "//src/agent:format_queue",
+        "//src/agent:instance_field_reader",
+        "//src/agent:jni_utils_h",
+        "//src/agent:jvm_breakpoint",
+        "//src/agent:jvm_evaluators",
+        "//src/agent:messages",
+        "//src/agent:method_locals",
+        "//src/agent:model_json",
+        "//src/agent:model_util",
+        "//src/agent:object_evaluator",
+        "//src/agent:resolved_source_location",
+        "//src/agent:static_field_reader",
+        "//src/agent:statistician",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "jvm_breakpoints_manager_test",
+    srcs = ["jvm_breakpoints_manager_test.cc"],
+    copts = [
+        "-Isrc/agent",
+        "-I$(BINDIR)/src/codegen/generated",
+    ],
+    deps = [
+        ":fake_jni",
+        ":mock_breakpoint",
+        ":mock_bridge",
+        ":mock_class_indexer",
+        ":mock_class_metadata_reader",
+        ":mock_class_path_lookup",
+        ":mock_dynamic_logger",
+        ":mock_eval_call_stack",
+        ":mock_jvmti_env",
+        ":mock_object_evaluator",
+        "//src/agent:callbacks_monitor",
+        "//src/agent:format_queue",
+        "//src/agent:jvm_breakpoints_manager",
+        "//src/agent:jvm_evaluators",
+        "//src/agent:messages",
+        "//src/agent:method_locals",
+        "//src/agent:model_util",
+        "//src/agent:object_evaluator",
+        "//src/agent:resolved_source_location",
+        "//src/agent:statistician",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
 
 cc_test(
     name = "jvm_eval_call_stack_test",
@@ -541,11 +573,42 @@ cc_library(
 )
 
 cc_library(
+    name = "mock_class_metadata_reader",
+    testonly = 1,
+    hdrs = ["mock_class_metadata_reader.h"],
+    deps = [
+        "//src/agent:class_metadata_reader",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_library(
+    name = "mock_class_path_lookup",
+    testonly = 1,
+    hdrs = ["mock_class_path_lookup.h"],
+    deps = [
+        "//src/agent:class_path_lookup",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_library(
     name = "mock_data_visibility_policy",
     testonly = 1,
     hdrs = ["mock_data_visibility_policy.h"],
     deps = [
         "//src/agent:data_visibility_policy",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_library(
+    name = "mock_dynamic_logger",
+    testonly = 1,
+    hdrs = ["mock_dynamic_logger.h"],
+    deps = [
+        "//src/agent:dynamic_logger",
+        "//src/agent:resolved_source_location",
         "@com_google_googletest//:gtest",
     ],
 )

--- a/tests/agent/BUILD
+++ b/tests/agent/BUILD
@@ -481,6 +481,18 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "jvm_local_variable_reader_test",
+    srcs = ["jvm_local_variable_reader_test.cc"],
+    deps = [
+        ":fake_jni",
+        ":mock_jvmti_env",
+        "//src/agent:jvm_local_variable_reader",
+        "//src/agent:readers_factory",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 jvm_test(
     name = "model_util_test",
     srcs = ["model_util_test.cc"],

--- a/tests/agent/BUILD
+++ b/tests/agent/BUILD
@@ -553,6 +553,18 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "jvm_static_field_reader_test",
+    srcs = ["jvm_static_field_reader_test.cc"],
+    deps = [
+        ":fake_jni",
+        ":mock_jni_env",
+        ":mock_jvmti_env",
+        "//src/agent:jvm_static_field_reader",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 jvm_test(
     name = "model_util_test",
     srcs = ["model_util_test.cc"],

--- a/tests/agent/BUILD
+++ b/tests/agent/BUILD
@@ -589,6 +589,21 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "method_locals_test",
+    srcs = ["method_locals_test.cc"],
+    deps = [
+        ":mock_jni_env",
+        ":mock_jvmti_env",
+        "//src/agent:common",
+        "//src/agent:local_variable_reader",
+        "//src/agent:method_locals",
+        "//src/agent:structured_data_visibility_policy",
+        "//src/agent:readers_factory",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 jvm_test(
     name = "model_util_test",
     srcs = ["model_util_test.cc"],

--- a/tests/agent/BUILD
+++ b/tests/agent/BUILD
@@ -537,6 +537,22 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "jvm_primitive_array_reader_test",
+    srcs = ["jvm_primitive_array_reader_test.cc"],
+    deps = [
+        ":fake_jni",
+        ":mock_jni_env",
+        ":mock_jvmti_env",
+        "//src/agent:jni_utils",
+        "//src/agent:jni_utils_h",
+        "//src/agent:jvm_primitive_array_reader",
+        "//src/agent:messages",
+        "//src/agent:model",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 jvm_test(
     name = "model_util_test",
     srcs = ["model_util_test.cc"],

--- a/tests/agent/BUILD
+++ b/tests/agent/BUILD
@@ -426,6 +426,19 @@ cc_test(
 )
 
 cc_test(
+    name = "jvm_class_indexer_test",
+    srcs = ["jvm_class_indexer_test.cc"],
+    deps = [
+        ":fake_jni",
+        ":mock_jni_env",
+        ":mock_jvmti_env",
+        "//src/agent:jni_utils_h",
+        "//src/agent:jvm_class_indexer",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "jvm_eval_call_stack_test",
     srcs = ["jvm_eval_call_stack_test.cc"],
     deps = [

--- a/tests/agent/BUILD
+++ b/tests/agent/BUILD
@@ -470,6 +470,17 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "jvm_instance_field_reader_test",
+    srcs = ["jvm_instance_field_reader_test.cc"],
+    deps = [
+        ":mock_jni_env",
+        ":mock_jvmti_env",
+        "//src/agent:jvm_instance_field_reader",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 jvm_test(
     name = "model_util_test",
     srcs = ["model_util_test.cc"],

--- a/tests/agent/BUILD
+++ b/tests/agent/BUILD
@@ -234,6 +234,50 @@ cc_test(
 )
 
 cc_test(
+    name = "format_queue_test",
+    srcs = ["format_queue_test.cc"],
+    deps = [
+        ":fake_jni",
+        ":mock_jvmti_env",
+        "//src/agent:config_builder",
+        "//src/agent:format_queue",
+        "//src/agent:model_util",
+        "//src/agent:statistician",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "generic_type_evaluator_test",
+    srcs = ["generic_type_evaluator_test.cc"],
+    deps = [
+        ":fake_instance_field_reader",
+        ":mock_jni_env",
+        ":mock_jvmti_env",
+        "//src/agent:generic_type_evaluator",
+        "//src/agent:messages",
+        "//src/agent:model",
+        "//src/agent:model_util",
+        "//src/agent:static_field_reader",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "glob_data_visibility_policy_test",
+    srcs = ["glob_data_visibility_policy_test.cc"],
+    deps = [
+        ":fake_jni",
+        ":mock_jvmti_env",
+        "//src/agent:glob_data_visibility_policy",
+        #"//util/glob",
+        #"//util/random:mt_random",
+        "@com_google_googletest//:gtest_main",
+        "@com_googlesource_code_re2//:re2",
+    ],
+)
+
+cc_test(
     name = "java_expression_parser_test",
     srcs = ["java_expression_parser_test.cc"],
     copts = [
@@ -261,6 +305,23 @@ cc_test(
         "//src/agent:jni_method_caller",
         "//src/agent:jni_utils",
         "//src/agent:jni_utils_h",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "jni_utils_test",
+    srcs = ["jni_utils_test.cc"],
+    copts = [
+        "-Isrc/agent",
+        "-I$(BINDIR)/src/codegen/generated",
+    ],
+    deps = [
+        ":fake_jni",
+        ":mock_jvmti_env",
+        "//src/agent:jni_utils",
+        "//src/agent:jni_utils_h",
+        "//src/codegen:mock_jni_proxies",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -296,6 +357,41 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+#cc_test(
+#    name = "jvm_breakpoint_test",
+#    srcs = ["jvm_breakpoint_test.cc"],
+#    deps = [
+#        ":fake_jni",
+#        ":json_eq_matcher",
+#        ":mock_breakpoint_labels_provider",
+#        ":mock_breakpoints_manager",
+#        ":mock_class_indexer",
+#        ":mock_class_metadata_reader",
+#        ":mock_class_path_lookup",
+#        ":mock_dynamic_logger",
+#        ":mock_eval_call_stack",
+#        ":mock_jvmti_env",
+#        ":mock_object_evaluator",
+#        ":mock_user_id_provider",
+#        "//src/agent:class_metadata_reader",
+#        "//src/agent:config_builder",
+#        "//src/agent:format_queue",
+#        "//src/agent:instance_field_reader",
+#        "//src/agent:jni_utils_h",
+#        "//src/agent:jvm_breakpoint",
+#        "//src/agent:jvm_evaluators",
+#        "//src/agent:messages",
+#        "//src/agent:method_locals",
+#        "//src/agent:model_json",
+#        "//src/agent:model_util",
+#        "//src/agent:object_evaluator",
+#        "//src/agent:resolved_source_location",
+#        "//src/agent:static_field_reader",
+#        "//src/agent:statistician",
+#        "@com_google_googletest//:gtest_main",
+#    ],
+#)
 
 cc_test(
     name = "jvm_eval_call_stack_test",

--- a/tests/agent/BUILD
+++ b/tests/agent/BUILD
@@ -493,6 +493,22 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "jvm_object_array_reader_test",
+    srcs = ["jvm_object_array_reader_test.cc"],
+    deps = [
+        ":fake_jni",
+        ":mock_jni_env",
+        ":mock_jvmti_env",
+        "//src/agent:jni_utils",
+        "//src/agent:jni_utils_h",
+        "//src/agent:jvm_object_array_reader",
+        "//src/agent:messages",
+        "//src/agent:model",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 jvm_test(
     name = "model_util_test",
     srcs = ["model_util_test.cc"],

--- a/tests/agent/class_file_test.cc
+++ b/tests/agent/class_file_test.cc
@@ -199,7 +199,7 @@ static std::string PrintString(jstring str) {
         break;
 
       default:
-        // TODO(vlif): encode non-ASCII characters like ASM does.
+        // TODO: encode non-ASCII characters like ASM does.
         ss << static_cast<char>(ch);
         break;
     }

--- a/tests/agent/format_queue_test.cc
+++ b/tests/agent/format_queue_test.cc
@@ -1,0 +1,217 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/agent/format_queue.h"
+
+#include "gtest/gtest.h"
+#include "src/agent/model_util.h"
+#include "src/agent/statistician.h"
+#include "tests/agent/fake_jni.h"
+#include "tests/agent/mock_jvmti_env.h"
+
+namespace devtools {
+namespace cdbg {
+
+class FormatQueueTest : public ::testing::Test {
+ protected:
+  FormatQueueTest() : global_jvm_(fake_jni_.jvmti(), fake_jni_.jni()) {}
+
+  void SetUp() override {
+    InitializeStatisticians();
+  }
+
+  void TearDown() override {
+    CleanupStatisticians();
+  }
+
+ protected:
+  FakeJni fake_jni_;
+  GlobalJvmEnv global_jvm_;
+};
+
+
+TEST_F(FormatQueueTest, IncorrectPop) {
+  FormatQueue format_queue;
+  EXPECT_EQ(nullptr, format_queue.FormatAndPop());
+}
+
+
+TEST_F(FormatQueueTest, EnqueueAndDequeue) {
+  std::unique_ptr<BreakpointModel> breakpoint(new BreakpointModel);
+  BreakpointModel* breakpoint_ptr = breakpoint.get();
+
+  FormatQueue format_queue;
+  format_queue.Enqueue(std::move(breakpoint), nullptr);
+  EXPECT_EQ(breakpoint_ptr, format_queue.FormatAndPop().get());
+  EXPECT_EQ(nullptr, format_queue.FormatAndPop());
+}
+
+
+TEST_F(FormatQueueTest, MaxLimit) {
+  FormatQueue format_queue;
+  for (int i = 0; i < kMaxFormatQueueSize + 10; ++i) {
+    std::unique_ptr<BreakpointModel> breakpoint(new BreakpointModel);
+    breakpoint->id = "ID" + std::to_string(i);
+
+    format_queue.Enqueue(std::move(breakpoint), nullptr);
+  }
+
+  int count = 0;
+  while (format_queue.FormatAndPop() != nullptr) {
+    ++count;
+  }
+
+  EXPECT_EQ(kMaxFormatQueueSize, count);
+}
+
+
+TEST_F(FormatQueueTest, ExpressionNames_Copy) {
+  std::unique_ptr<BreakpointModel> breakpoint = BreakpointBuilder()
+      .set_id("ID")
+      .set_expressions({ "1+1", "2+2", "3+3" })
+      .add_evaluated_expression(VariableBuilder().set_value("2"))
+      .add_evaluated_expression(VariableBuilder().set_value("4"))
+      .add_evaluated_expression(VariableBuilder().set_value("6"))
+      .build();
+
+  FormatQueue format_queue;
+  format_queue.Enqueue(std::move(breakpoint), nullptr);
+
+  breakpoint = format_queue.FormatAndPop();
+  EXPECT_EQ(3, breakpoint->evaluated_expressions.size());
+  EXPECT_EQ("1+1", breakpoint->evaluated_expressions[0]->name);
+  EXPECT_EQ("2+2", breakpoint->evaluated_expressions[1]->name);
+  EXPECT_EQ("3+3", breakpoint->evaluated_expressions[2]->name);
+}
+
+
+TEST_F(FormatQueueTest, ExpressionNames_NoEvaluatedExpressions) {
+  std::unique_ptr<BreakpointModel> breakpoint = BreakpointBuilder()
+      .set_id("ID")
+      .set_expressions({ "1+1", "2+2", "3+3" })
+      .build();
+
+  FormatQueue format_queue;
+  format_queue.Enqueue(std::move(breakpoint), nullptr);
+
+  breakpoint = format_queue.FormatAndPop();
+  EXPECT_EQ(0, breakpoint->evaluated_expressions.size());
+}
+
+
+TEST_F(FormatQueueTest, RemoveAll) {
+  std::unique_ptr<BreakpointModel> breakpoint(new BreakpointModel);
+
+  FormatQueue format_queue;
+  format_queue.Enqueue(std::move(breakpoint), nullptr);
+
+  format_queue.RemoveAll();
+
+  EXPECT_EQ(nullptr, format_queue.FormatAndPop());
+}
+
+
+TEST_F(FormatQueueTest, EnqueueEvent) {
+  FormatQueue format_queue;
+
+  int events_counter = 0;
+  auto cookie = format_queue.SubscribeOnItemEnqueuedEvents(
+      [&events_counter]() { ++events_counter; });
+
+  for (int i = 0; i < 7; ++i) {
+    std::unique_ptr<BreakpointModel> breakpoint(new BreakpointModel);
+    breakpoint->id = "ID" + std::to_string(i);
+
+    format_queue.Enqueue(std::move(breakpoint), nullptr);
+  }
+
+  format_queue.UnsubscribeOnItemEnqueuedEvents(std::move(cookie));
+
+  format_queue.Enqueue(
+      std::unique_ptr<BreakpointModel>(new BreakpointModel),
+      nullptr);
+
+  format_queue.RemoveAll();
+
+  EXPECT_EQ(7, events_counter);
+}
+
+
+TEST_F(FormatQueueTest, RepeatedEnqueueNonFinalState) {
+  FormatQueue format_queue;
+
+  for (int i = 0; i < 1000; ++i) {
+    format_queue.Enqueue(
+        BreakpointBuilder()
+            .set_id("ID")
+            .set_location("path", i)
+            .build(),
+        nullptr);
+  }
+
+  std::unique_ptr<BreakpointModel> breakpoint = format_queue.FormatAndPop();
+  EXPECT_NE(nullptr, breakpoint);
+  EXPECT_EQ(999, breakpoint->location->line);
+
+  EXPECT_EQ(nullptr, format_queue.FormatAndPop());
+}
+
+
+TEST_F(FormatQueueTest, RepeatedEnqueueNonFinalStateReplacedByFinal) {
+  FormatQueue format_queue;
+
+  format_queue.Enqueue(
+      BreakpointBuilder()
+          .set_id("ID")
+          .set_location("interim", 0)
+          .build(),
+      nullptr);
+
+  format_queue.Enqueue(
+      BreakpointBuilder()
+          .set_id("ID")
+          .set_is_final_state(true)
+          .set_location("final", 0)
+          .build(),
+      nullptr);
+
+  std::unique_ptr<BreakpointModel> breakpoint = format_queue.FormatAndPop();
+  EXPECT_NE(nullptr, breakpoint);
+  EXPECT_EQ("final", breakpoint->location->path);
+
+  EXPECT_EQ(nullptr, format_queue.FormatAndPop());
+}
+
+
+TEST_F(FormatQueueTest, RepeatedEnqueueFinalState) {
+  FormatQueue format_queue;
+
+  for (int i = 0; i < 1000; ++i) {
+    std::unique_ptr<BreakpointModel> breakpoint(new BreakpointModel);
+    breakpoint->id = "ID";
+    breakpoint->is_final_state = true;
+
+    format_queue.Enqueue(std::move(breakpoint), nullptr);
+  }
+
+  EXPECT_NE(nullptr, format_queue.FormatAndPop());
+  EXPECT_EQ(nullptr, format_queue.FormatAndPop());
+}
+
+
+}  // namespace cdbg
+}  // namespace devtools
+

--- a/tests/agent/generic_type_evaluator_test.cc
+++ b/tests/agent/generic_type_evaluator_test.cc
@@ -1,0 +1,204 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/agent/generic_type_evaluator.h"
+
+#include "gtest/gtest.h"
+#include "src/agent/messages.h"
+#include "src/agent/model.h"
+#include "src/agent/model_util.h"
+#include "src/agent/static_field_reader.h"
+#include "tests/agent/fake_instance_field_reader.h"
+#include "tests/agent/mock_jni_env.h"
+#include "tests/agent/mock_jvmti_env.h"
+
+using testing::_;
+using testing::AtMost;
+using testing::DoAll;
+using testing::Eq;
+using testing::IsNull;
+using testing::NotNull;
+using testing::Test;
+using testing::Return;
+using testing::ReturnRef;
+using testing::StrEq;
+using testing::WithArgs;
+using testing::Invoke;
+using testing::InvokeArgument;
+using testing::SetArgPointee;
+
+namespace devtools {
+namespace cdbg {
+
+static const jobject kEvaluatedObject =
+    reinterpret_cast<jobject>(0x8723456467453L);
+
+class GenericTypeEvaluatorTest : public ::testing::Test {
+ protected:
+  GenericTypeEvaluatorTest()
+      : global_jvm_(&jvmti_, &jni_) {
+  }
+
+  void SetUp() override {
+    EXPECT_CALL(jni_, NewGlobalRef(_))
+        .WillRepeatedly(Invoke([] (jobject obj) { return obj; }));
+
+    EXPECT_CALL(jni_, DeleteLocalRef(_))
+        .WillRepeatedly(Return());
+
+    EXPECT_CALL(jni_, DeleteGlobalRef(_))
+        .WillRepeatedly(Return());
+
+    EXPECT_CALL(jni_, IsSameObject(_, _))
+        .WillRepeatedly(Invoke([] (jobject obj1, jobject obj2) {
+          return obj1 == obj2;
+        }));
+
+    EXPECT_CALL(jni_, GetObjectRefType(_))
+        .WillRepeatedly(Return(JNILocalRefType));
+  }
+
+  static bool IsSameObject(jobject obj1, jobject obj2) {
+    return obj1 == obj2;
+  }
+
+  static jobject NewRef(jobject src) {
+    return src;
+  }
+
+  std::vector<std::string> FormatResults() {
+    std::vector<std::string> v;
+    for (const NamedJVariant& var : eval_result_) {
+      std::ostringstream os;
+      os << var.name << ": ";
+
+      if (!var.status.description.format.empty()) {
+        os << " [" << var.status << "]";
+      } else {
+        os << var.value.ToString(false);
+      }
+
+      v.push_back(os.str());
+    }
+
+    return v;
+  }
+
+  void Evaluate(const ClassMetadataReader::Entry& class_metadata) {
+    evaluator_.Evaluate(
+        nullptr,  // "MethodCaller" not used by "GenericTypeEvaluator".
+        class_metadata,
+        kEvaluatedObject,
+        false,
+        &eval_result_);
+  }
+
+ protected:
+  MockJvmtiEnv jvmti_;
+  MockJNIEnv jni_;
+  GlobalJvmEnv global_jvm_;
+  GenericTypeEvaluator evaluator_;
+  std::vector<NamedJVariant> eval_result_;
+};
+
+
+TEST_F(GenericTypeEvaluatorTest, EmptyObject) {
+  ClassMetadataReader::Entry metadata;
+  metadata.signature = { JType::Object, "LMyEvaluatedClass;" };
+
+  Evaluate(metadata);
+
+  std::vector<std::string> expected_results = {
+      ":  [info(6) (\"Object has no fields\")]",
+  };
+
+  EXPECT_EQ(expected_results, FormatResults());
+}
+
+
+TEST_F(GenericTypeEvaluatorTest, SingleField) {
+  FakeInstanceFieldReader fields[] = {
+    { "myint", { JType::Int }, JVariant::Int(427) }
+  };
+
+  ClassMetadataReader::Entry metadata;
+  metadata.signature = { JType::Object, "LMyEvaluatedClass;" };
+
+  for (const FakeInstanceFieldReader& field : fields) {
+    metadata.instance_fields.push_back(field.Clone());
+  }
+
+  Evaluate(metadata);
+
+  EXPECT_EQ(std::vector<std::string>({"myint: <int>427"}), FormatResults());
+}
+
+
+TEST_F(GenericTypeEvaluatorTest, MultipleFields) {
+  FakeInstanceFieldReader fields[] = {
+    {
+      "myint",
+      { JType::Int },
+      JVariant::Int(427)
+    },
+    {
+      "mybool",
+      { JType::Boolean },
+      JVariant::Boolean(true)
+    },
+    {
+      "mylong",
+      { JType::Long },
+      JVariant::Long(12345678987654321L)
+    }
+  };
+
+  ClassMetadataReader::Entry metadata;
+  metadata.signature = { JType::Object, "LMyEvaluatedClass;" };
+
+  for (const FakeInstanceFieldReader& field : fields) {
+    metadata.instance_fields.push_back(field.Clone());
+  }
+
+  Evaluate(metadata);
+
+  std::vector<std::string> expected_results = {
+      "myint: <int>427",
+      "mybool: <boolean>true",
+      "mylong: <long>12345678987654321",
+  };
+
+  EXPECT_EQ(expected_results, FormatResults());
+}
+
+
+TEST_F(GenericTypeEvaluatorTest, InstanceFieldsOmitted) {
+  ClassMetadataReader::Entry metadata;
+  metadata.signature = { JType::Object, "LMyEvaluatedClass;" };
+  metadata.instance_fields_omitted = true;
+
+  Evaluate(metadata);
+
+  std::vector<std::string> expected_results = {
+      ":  [info(6) (\"" + std::string(InstanceFieldsOmitted) + "\")]",
+  };
+
+  EXPECT_EQ(expected_results, FormatResults());
+}
+
+
+}  // namespace cdbg
+}  // namespace devtools

--- a/tests/agent/glob_data_visibility_policy_test.cc
+++ b/tests/agent/glob_data_visibility_policy_test.cc
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "src/agent/glob_data_visibility_policy.h"
 
 #include <cstdint>

--- a/tests/agent/glob_data_visibility_policy_test.cc
+++ b/tests/agent/glob_data_visibility_policy_test.cc
@@ -1,0 +1,488 @@
+#include "src/agent/glob_data_visibility_policy.h"
+
+#include <cstdint>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "re2/re2.h"
+#include "tests/agent/fake_jni.h"
+#include "tests/agent/mock_jvmti_env.h"
+
+namespace devtools {
+namespace cdbg {
+
+using ::testing::Invoke;
+using ::testing::NotNull;
+using ::testing::WithArg;
+
+static const jclass kClass = reinterpret_cast<jclass>(0x12345678);
+
+class GlobDataVisibilityPolicyTest : public ::testing::Test {
+ protected:
+  GlobDataVisibilityPolicyTest()
+      : fake_jni_(&jvmti_),
+        global_jvm_(&jvmti_, fake_jni_.jni()) {
+  }
+
+  void SetUp() override {
+    EXPECT_CALL(jvmti_, Deallocate(NotNull()))
+        .WillRepeatedly(Invoke([] (unsigned char* buffer) {
+          delete[] buffer;
+          return JVMTI_ERROR_NONE;
+        }));
+  }
+
+  void SetClassSignature(const std::string& signature) {
+    EXPECT_CALL(jvmti_, GetClassSignature(kClass, NotNull(), nullptr))
+        .WillRepeatedly(WithArg<1>(Invoke([signature] (char** buffer) {
+          *buffer = new char[signature.size() + 1];
+          memcpy(*buffer, signature.c_str(), signature.size() + 1);
+          return JVMTI_ERROR_NONE;
+        })));
+  }
+
+  void CheckIsBlocked(const std::vector<std::string>& signatures,
+                          const GlobDataVisibilityPolicy::Config& config) {
+    GlobDataVisibilityPolicy data_visibility;
+    data_visibility.SetConfig(config);
+    for (const std::string& signature : signatures) {
+      SetClassSignature(signature);
+      auto class_visibility = data_visibility.GetClassVisibility(kClass);
+      ASSERT_NE(nullptr, class_visibility);
+
+      std::string reason;
+      EXPECT_TRUE(class_visibility->IsFieldVisible("someField", 0));
+      EXPECT_FALSE(class_visibility->IsMethodVisible("myMethod", "()V", 0));
+      EXPECT_FALSE(
+          class_visibility->IsFieldDataVisible("someField", 0, &reason));
+      EXPECT_TRUE(
+          class_visibility->IsVariableVisible("myMethod", "()V", "var"));
+      EXPECT_FALSE(
+          class_visibility->IsVariableDataVisible(
+              "myMethod", "()V", "var", &reason));
+    }
+  }
+
+  void CheckIsNull(const std::vector<std::string>& paths,
+                   const GlobDataVisibilityPolicy::Config& config) {
+    GlobDataVisibilityPolicy data_visibility;
+    data_visibility.SetConfig(config);
+    for (const std::string& path : paths) {
+      SetClassSignature(path);
+      auto class_visibility = data_visibility.GetClassVisibility(kClass);
+      ASSERT_EQ(nullptr, class_visibility);
+    }
+  }
+
+ protected:
+  MockJvmtiEnv jvmti_;
+  FakeJni fake_jni_;
+  GlobalJvmEnv global_jvm_;
+};
+
+
+TEST_F(GlobDataVisibilityPolicyTest, BadClassSignature) {
+  std::vector<std::string> bad_signatures = {
+      "Lcom/public/MyClass",
+      "com/public/MyClass;",
+      "L;",
+      "L",
+      ";"
+      "",
+  };
+
+  CheckIsNull(bad_signatures, {});
+}
+
+
+TEST_F(GlobDataVisibilityPolicyTest, NothingIsBlocked) {
+  std::vector<std::string> not_blocked = {
+      "Lcom/public/MyClass;",
+      "Lcom/public/MyClass$Inner1;",
+      "Lcom/public/MyClass$Inner1$Inner2;",
+  };
+
+  GlobDataVisibilityPolicy::Config config;
+  config.blocklists.Prepare();
+  config.blocklist_exceptions.Prepare();
+  CheckIsNull(not_blocked, config);
+}
+
+
+TEST_F(GlobDataVisibilityPolicyTest, PackageBlocked) {
+  std::vector<std::string> blocked = {
+      "Lcom/secret/MyClass;",
+      "Lcom/secret/MyClass$Inner1;",
+      "Lcom/secret/MyClass$Inner1$Inner2;",
+  };
+
+  std::vector<std::string> not_blocked = {
+      "Lcom/public/MyClass;",
+      "Lcom/public/MyClass$Inner1;",
+      "Lcom/public/MyClass$Inner1$Inner2;",
+  };
+
+  GlobDataVisibilityPolicy::Config config;
+  config.blocklists.Add("com.secret");
+  config.blocklists.Prepare();
+  config.blocklist_exceptions.Prepare();
+
+  CheckIsBlocked(blocked, config);
+  CheckIsNull(not_blocked, config);
+}
+
+
+TEST_F(GlobDataVisibilityPolicyTest, PackageIsNotBlocked) {
+  std::vector<std::string> blocked = {
+      "Lcom/secret/MyClass;",
+      "Lcom/secret/MyClass$Inner1;",
+      "Lcom/secret/MyClass$Inner1$Inner2;",
+  };
+
+  std::vector<std::string> not_blocked = {
+      "Lcom/public/MyClass;",
+      "Lcom/public/MyClass$Inner1;",
+      "Lcom/public/MyClass$Inner1$Inner2;",
+  };
+
+  GlobDataVisibilityPolicy::Config config;
+  config.blocklists.Add("!com.public");
+  config.blocklists.Prepare();
+  config.blocklist_exceptions.Prepare();
+
+  CheckIsBlocked(blocked, config);
+  CheckIsNull(not_blocked, config);
+}
+
+
+TEST_F(GlobDataVisibilityPolicyTest, PackageWhitelisted) {
+  std::vector<std::string> blocked = {
+      "Lcom/secret/MyClass;",
+      "Lcom/secret/MyClass$Inner1;",
+      "Lcom/secret/MyClass$Inner1$Inner2;",
+  };
+
+  std::vector<std::string> not_blocked = {
+      "Lcom/public/MyClass;",
+      "Lcom/public/MyClass$Inner1;",
+      "Lcom/public/MyClass$Inner1$Inner2;",
+  };
+
+  GlobDataVisibilityPolicy::Config config;
+  config.blocklists.Add("*");
+  config.blocklist_exceptions.Add("com.public");
+  config.blocklists.Prepare();
+  config.blocklist_exceptions.Prepare();
+
+  CheckIsBlocked(blocked, config);
+  CheckIsNull(not_blocked, config);
+}
+
+
+TEST_F(GlobDataVisibilityPolicyTest, PackageWhitelistedWithInverse) {
+  std::vector<std::string> blocked = {
+      "Lcom/secret/MyClass;",
+      "Lcom/secret/MyClass$Inner1;",
+      "Lcom/secret/MyClass$Inner1$Inner2;",
+  };
+
+  std::vector<std::string> not_blocked = {
+      "Lcom/public/MyClass;",
+      "Lcom/public/MyClass$Inner1;",
+      "Lcom/public/MyClass$Inner1$Inner2;",
+  };
+
+  GlobDataVisibilityPolicy::Config config;
+  config.blocklists.Add("!com.test");
+  config.blocklist_exceptions.Add("com.public");
+  config.blocklists.Prepare();
+  config.blocklist_exceptions.Prepare();
+
+  CheckIsBlocked(blocked, config);
+  CheckIsNull(not_blocked, config);
+}
+
+
+TEST_F(GlobDataVisibilityPolicyTest, ClassBlocked) {
+  std::vector<std::string> blocked = {
+      "Lcom/secret/MyClass;",
+      "Lcom/secret/MyClass$Inner1;",
+      "Lcom/secret/MyClass$Inner1$Inner2;",
+  };
+
+  std::vector<std::string> not_blocked = {
+      "Lcom/public/MyClass;",
+      "Lcom/public/MyClass$Inner1;",
+      "Lcom/public/MyClass$Inner1$Inner2;",
+  };
+
+  GlobDataVisibilityPolicy::Config config;
+  config.blocklists.Add("com.secret.MyClass");
+  config.blocklists.Prepare();
+  config.blocklist_exceptions.Prepare();
+
+  CheckIsBlocked(blocked, config);
+  CheckIsNull(not_blocked, config);
+}
+
+
+TEST_F(GlobDataVisibilityPolicyTest, ClassWhitelisted) {
+  std::vector<std::string> blocked = {
+      "Lcom/secret/MyClass;",
+      "Lcom/secret/MyClass$Inner1;",
+      "Lcom/secret/MyClass$Inner1$Inner2;",
+  };
+
+  std::vector<std::string> not_blocked = {
+      "Lcom/public/MyClass;",
+      "Lcom/public/MyClass$Inner1;",
+      "Lcom/public/MyClass$Inner1$Inner2;",
+  };
+
+  GlobDataVisibilityPolicy::Config config;
+  config.blocklists.Add("*");
+  config.blocklist_exceptions.Add("com.public.MyClass");
+  config.blocklists.Prepare();
+  config.blocklist_exceptions.Prepare();
+
+  CheckIsBlocked(blocked, config);
+  CheckIsNull(not_blocked, config);
+}
+
+
+TEST_F(GlobDataVisibilityPolicyTest, OnlyClassNotBlocked) {
+  std::vector<std::string> blocked = {
+      "Lcom/secret/MyClass;",
+      "Lcom/secret/MyClass$Inner1;",
+      "Lcom/secret/MyClass$Inner1$Inner2;",
+  };
+
+  std::vector<std::string> not_blocked = {
+      "Lcom/public/MyClass;",
+      "Lcom/public/MyClass$Inner1;",
+      "Lcom/public/MyClass$Inner1$Inner2;",
+  };
+
+  GlobDataVisibilityPolicy::Config config;
+  config.blocklists.Add("!com.public.MyClass");
+  config.blocklists.Prepare();
+  config.blocklist_exceptions.Prepare();
+
+  CheckIsBlocked(blocked, config);
+  CheckIsNull(not_blocked, config);
+}
+
+// Blocklist everything not in com.public
+// Also blocklist com.public.User
+// Allow com.public.User.Test (and children)
+TEST_F(GlobDataVisibilityPolicyTest, ExceptionWithinNamespace) {
+  std::vector<std::string> blocked = {
+      "Lcom/secret/MyClass;",
+      "Lcom/public/User;",
+      "Lcom/public/User/Password;",
+  };
+
+  std::vector<std::string> not_blocked = {
+      "Lcom/public/MyClass;",
+      "Lcom/public/User/Test;",
+      "Lcom/public/User/Test/UserTest;",
+  };
+
+  GlobDataVisibilityPolicy::Config config;
+  config.blocklists.Add("!com.public");
+  config.blocklists.Add("com.public.User");
+  config.blocklist_exceptions.Add("com.public.User.Test");
+  config.blocklists.Prepare();
+  config.blocklist_exceptions.Prepare();
+
+  CheckIsBlocked(blocked, config);
+  CheckIsNull(not_blocked, config);
+}
+
+
+TEST_F(GlobDataVisibilityPolicyTest, ParseError) {
+  GlobDataVisibilityPolicy::Config config;
+  config.parse_error = "parse error";
+
+  GlobDataVisibilityPolicy policy;
+  policy.SetConfig(config);
+  std::string setup_error;
+  EXPECT_TRUE(policy.HasSetupError(&setup_error));
+  EXPECT_EQ("parse error", setup_error);
+
+  std::unique_ptr<DataVisibilityPolicy::Class> cls =
+      policy.GetClassVisibility(nullptr);
+
+  EXPECT_TRUE(cls->IsFieldVisible("name", 0));
+  EXPECT_FALSE(cls->IsMethodVisible("name", "sig", 0));
+  EXPECT_TRUE(cls->IsVariableVisible("method_name", "method_sig", "name"));
+
+  std::string field_error;
+  EXPECT_FALSE(cls->IsFieldDataVisible("name", 0, &field_error));
+  EXPECT_EQ(config.parse_error, field_error);
+
+  std::string variable_error;
+  EXPECT_FALSE(cls->IsVariableDataVisible(
+      "method_name",
+      "method_sig",
+      "name",
+      &variable_error));
+  EXPECT_EQ(config.parse_error, variable_error);
+}
+
+
+TEST_F(GlobDataVisibilityPolicyTest, Uninitialized) {
+  GlobDataVisibilityPolicy policy;
+  std::string error;
+  EXPECT_TRUE(policy.HasSetupError(&error));
+
+  std::unique_ptr<DataVisibilityPolicy::Class> cls =
+      policy.GetClassVisibility(nullptr);
+
+  EXPECT_FALSE(cls->IsMethodVisible("name", "sig", 0));
+  EXPECT_FALSE(cls->IsFieldDataVisible("name", 0, &error));
+  EXPECT_FALSE(cls->IsVariableDataVisible(
+      "method_name",
+      "method_sig",
+      "name",
+      &error));
+}
+
+
+TEST(GlobSetTest, MatchesAny) {
+  GlobDataVisibilityPolicy::GlobSet glob;
+  glob.Add("*");
+  glob.Prepare();
+  EXPECT_TRUE(glob.Matches("foo"));
+  EXPECT_TRUE(glob.Matches(""));
+}
+
+TEST(GlobSetTest, MatchesNone) {
+  GlobDataVisibilityPolicy::GlobSet glob;
+  glob.Add("!*");
+  glob.Prepare();
+  EXPECT_FALSE(glob.Matches("foo"));
+  EXPECT_FALSE(glob.Matches(""));
+}
+
+TEST(GlobSetTest, MatchesPrefix) {
+  GlobDataVisibilityPolicy::GlobSet glob;
+  glob.Add("foo*");
+  glob.Prepare();
+  EXPECT_TRUE(glob.Matches("foo"));
+  EXPECT_TRUE(glob.Matches("foot"));
+  EXPECT_FALSE(glob.Matches("fo"));
+  EXPECT_FALSE(glob.Matches("fog"));
+}
+
+TEST(GlobSetTest, DoesNotMatchPrefix) {
+  GlobDataVisibilityPolicy::GlobSet glob;
+  glob.Add("!foo*");
+  glob.Prepare();
+  EXPECT_FALSE(glob.Matches("foo"));
+  EXPECT_FALSE(glob.Matches("foot"));
+  EXPECT_TRUE(glob.Matches("fo"));
+  EXPECT_TRUE(glob.Matches("fog"));
+}
+
+TEST(GlobSetTest, MatchesSuffix) {
+  GlobDataVisibilityPolicy::GlobSet glob;
+  glob.Add("*foo");
+  glob.Prepare();
+  EXPECT_TRUE(glob.Matches("foo"));
+  EXPECT_TRUE(glob.Matches("tfoo"));
+  EXPECT_FALSE(glob.Matches("fo"));
+  EXPECT_FALSE(glob.Matches("fog"));
+  EXPECT_FALSE(glob.Matches("foot"));
+  EXPECT_FALSE(glob.Matches(""));
+}
+
+TEST(GlobSetTest, DoesNotMatchSuffix) {
+  GlobDataVisibilityPolicy::GlobSet glob;
+  glob.Add("!*foo");
+  glob.Prepare();
+  EXPECT_FALSE(glob.Matches("foo"));
+  EXPECT_FALSE(glob.Matches("tfoo"));
+  EXPECT_TRUE(glob.Matches("fo"));
+  EXPECT_TRUE(glob.Matches("fog"));
+  EXPECT_TRUE(glob.Matches("foot"));
+  EXPECT_TRUE(glob.Matches(""));
+}
+
+TEST(GlobSetTest, MatchesExact) {
+  GlobDataVisibilityPolicy::GlobSet glob;
+  glob.Add("foo");
+  glob.Prepare();
+  EXPECT_TRUE(glob.Matches("foo"));
+  EXPECT_FALSE(glob.Matches("fo"));
+  EXPECT_FALSE(glob.Matches("oo"));
+  EXPECT_FALSE(glob.Matches("foot"));
+  EXPECT_FALSE(glob.Matches("tfoo"));
+  EXPECT_FALSE(glob.Matches(""));
+}
+
+TEST(GlobSetTest, DoesNotMatchExact) {
+  GlobDataVisibilityPolicy::GlobSet glob;
+  glob.Add("!foo");
+  glob.Prepare();
+  EXPECT_FALSE(glob.Matches("foo"));
+  EXPECT_TRUE(glob.Matches("fo"));
+  EXPECT_TRUE(glob.Matches("oo"));
+  EXPECT_TRUE(glob.Matches("foot"));
+  EXPECT_TRUE(glob.Matches("tfoo"));
+  EXPECT_TRUE(glob.Matches(""));
+}
+
+TEST(GlobSetTest, MultipleGlobs) {
+  GlobDataVisibilityPolicy::GlobSet glob;
+  glob.Add("foo");
+  glob.Add("bar");
+  glob.Add("baz*");
+  glob.Prepare();
+  EXPECT_TRUE(glob.Matches("foo"));
+  EXPECT_TRUE(glob.Matches("bar"));
+  EXPECT_TRUE(glob.Matches("baz2"));
+  EXPECT_FALSE(glob.Matches("abc"));
+  EXPECT_FALSE(glob.Matches(""));
+}
+
+TEST(GlobSetTest, RestrictNamespace) {
+  GlobDataVisibilityPolicy::GlobSet glob;
+  glob.Add("!com.foo.*");
+  glob.Add("com.foo.security.*");
+  glob.Add("com.foo.user");
+  glob.Prepare();
+  EXPECT_TRUE(glob.Matches("java.util.Arrays"));
+  EXPECT_TRUE(glob.Matches("com.foo.security.Token"));
+  EXPECT_TRUE(glob.Matches("com.foo.user"));
+  EXPECT_FALSE(glob.Matches("com.foo.test.TestCase"));
+}
+
+TEST(GlobSetTest, RestrictNamespaceNoGlobs) {
+  GlobDataVisibilityPolicy::GlobSet glob;
+  glob.Add("!com.foo");
+  glob.Add("com.foo.security");
+  glob.Add("com.foo.user");
+  glob.Prepare();
+  EXPECT_TRUE(glob.Matches("java.util.Arrays"));
+  EXPECT_TRUE(glob.Matches("com.foo.security.Token"));
+  EXPECT_TRUE(glob.Matches("com.foo.user"));
+  EXPECT_FALSE(glob.Matches("com.foo.test.TestCase"));
+}
+
+TEST(GlobSetTest, Empty) {
+  GlobDataVisibilityPolicy::GlobSet glob;
+  EXPECT_TRUE(glob.Empty());
+  glob.Add("foo");
+  EXPECT_FALSE(glob.Empty());
+}
+
+TEST(GlobSetTest, InverseEmpty) {
+  GlobDataVisibilityPolicy::GlobSet glob;
+  EXPECT_TRUE(glob.Empty());
+  glob.Add("!foo");
+  EXPECT_FALSE(glob.Empty());
+}
+
+}  // namespace cdbg
+}  // namespace devtools

--- a/tests/agent/jni_utils_test.cc
+++ b/tests/agent/jni_utils_test.cc
@@ -1,0 +1,179 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/agent/jni_utils.h"
+
+#include "gtest/gtest.h"
+#include "mock_object.h"
+#include "mock_printwriter.h"
+#include "mock_stringwriter.h"
+#include "mock_throwable.h"
+#include "tests/agent/fake_jni.h"
+#include "tests/agent/mock_jvmti_env.h"
+
+using testing::NiceMock;
+
+namespace devtools {
+namespace cdbg {
+
+class JniUtilsTest : public ::testing::Test {
+ protected:
+  JniUtilsTest() : global_jvm_(fake_jni_.jvmti(), fake_jni_.jni()) {}
+
+  void SetUp() override {
+    jniproxy::InjectObject(&object_);
+    jniproxy::InjectPrintWriter(&print_writer_);
+    jniproxy::InjectStringWriter(&string_writer_);
+    jniproxy::InjectThrowable(&throwable_);
+  }
+
+  void TearDown() override {
+    jniproxy::InjectObject(nullptr);
+    jniproxy::InjectPrintWriter(nullptr);
+    jniproxy::InjectStringWriter(nullptr);
+    jniproxy::InjectThrowable(nullptr);
+  }
+
+ protected:
+  FakeJni fake_jni_;
+  GlobalJvmEnv global_jvm_;
+  NiceMock<jniproxy::MockObject> object_;
+  NiceMock<jniproxy::MockPrintWriter> print_writer_;
+  NiceMock<jniproxy::MockStringWriter> string_writer_;
+  NiceMock<jniproxy::MockThrowable> throwable_;
+};
+
+
+TEST_F(JniUtilsTest, JniLocalRef_DefaultConstructor) {
+  JniLocalRef ref;
+  EXPECT_EQ(nullptr, ref.get());
+  EXPECT_EQ(nullptr, ref);
+}
+
+
+TEST_F(JniUtilsTest, JniLocalRef_AttachRef) {
+  JniLocalRef ref(fake_jni_.CreateNewJavaString("abc"));
+
+  EXPECT_NE(nullptr, ref.get());
+  EXPECT_NE(nullptr, ref);
+  EXPECT_EQ("abc", JniToNativeString(ref.get()));
+}
+
+
+TEST_F(JniUtilsTest, JniLocalRef_Reset) {
+  JniLocalRef ref(fake_jni_.CreateNewJavaString("abc"));
+
+  EXPECT_NE(nullptr, ref);
+
+  ref.reset();
+
+  EXPECT_EQ(nullptr, ref);
+}
+
+
+TEST_F(JniUtilsTest, JniLocalRef_Swap) {
+  JniLocalRef ref1(fake_jni_.CreateNewJavaString("abc"));
+  JniLocalRef ref2(fake_jni_.CreateNewJavaString("def"));
+
+  ref1.swap(ref2);
+
+  EXPECT_EQ("def", JniToNativeString(ref1.get()));
+  EXPECT_EQ("abc", JniToNativeString(ref2.get()));
+}
+
+
+TEST_F(JniUtilsTest, JniLocalRef_Release) {
+  JniLocalRef ref1(fake_jni_.CreateNewJavaString("abc"));
+  JniLocalRef ref2(ref1.release());
+
+  EXPECT_EQ(nullptr, ref1);
+  EXPECT_EQ("abc", JniToNativeString(ref2.get()));
+}
+
+
+TEST_F(JniUtilsTest, JniLocalRef_ResetOnAttach) {
+  JniLocalRef ref;
+  ref = JniLocalRef(fake_jni_.CreateNewJavaString("abc"));
+  ref = JniLocalRef(fake_jni_.CreateNewJavaString("def"));
+
+  EXPECT_EQ("def", JniToNativeString(ref.get()));
+
+  // "FakeJni" verifies that all the references were properly cleaned up.
+}
+
+
+TEST_F(JniUtilsTest, ExceptionOr_NoException) {
+  ExceptionOr<int> e = CatchOr(nullptr, 123);
+  EXPECT_FALSE(e.HasException());
+  EXPECT_EQ(nullptr, e.GetException());
+  EXPECT_EQ(123, e.GetData());
+  EXPECT_EQ(123, e.Release(ExceptionAction::IGNORE));
+  e.LogException();
+  EXPECT_EQ(123, e.Release(ExceptionAction::LOG_AND_IGNORE));
+}
+
+
+TEST_F(JniUtilsTest, ExceptionOr_WithException_NoLogContext) {
+  JniLocalRef exception(
+      fake_jni_.CreateNewObject(FakeJni::StockClass::Object));
+  EXPECT_EQ(0, jni()->Throw(static_cast<jthrowable>(exception.get())));
+
+  ExceptionOr<int> e = CatchOr(nullptr, 123);
+  EXPECT_FALSE(jni()->ExceptionCheck());
+
+  EXPECT_TRUE(e.HasException());
+  EXPECT_TRUE(jni()->IsSameObject(exception.get(), e.GetException()));
+  EXPECT_EQ(0, e.Release(ExceptionAction::IGNORE));
+  e.LogException();
+  EXPECT_EQ(0, e.Release(ExceptionAction::LOG_AND_IGNORE));
+}
+
+
+TEST_F(JniUtilsTest, ExceptionOr_WithException_WithContext) {
+  JniLocalRef exception(
+      fake_jni_.CreateNewObject(FakeJni::StockClass::Object));
+  EXPECT_EQ(0, jni()->Throw(static_cast<jthrowable>(exception.get())));
+
+  ExceptionOr<int> e = CatchOr("unit test", 123);
+  EXPECT_FALSE(jni()->ExceptionCheck());
+
+  e.LogException();
+  EXPECT_EQ(0, e.Release(ExceptionAction::LOG_AND_IGNORE));
+}
+
+
+TEST_F(JniUtilsTest, ExceptionOr_UniquePtr) {
+  ExceptionOr<std::unique_ptr<int>> e =
+      CatchOr(nullptr, std::unique_ptr<int>(new int(123)));
+
+  EXPECT_FALSE(e.HasException());
+  EXPECT_EQ(nullptr, e.GetException());
+  EXPECT_EQ(123, *e.GetData());
+  e.LogException();
+  EXPECT_EQ(123, *e.Release(ExceptionAction::IGNORE));
+}
+
+
+TEST_F(JniUtilsTest, ExceptionOr_Nothing) {
+  ExceptionOr<std::nullptr_t> e = CatchOr<std::nullptr_t>(nullptr, nullptr);
+
+  EXPECT_FALSE(e.HasException());
+  EXPECT_EQ(nullptr, e.GetException());
+}
+
+}  // namespace cdbg
+}  // namespace devtools
+

--- a/tests/agent/jvm_breakpoint_test.cc
+++ b/tests/agent/jvm_breakpoint_test.cc
@@ -1,0 +1,953 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/agent/jvm_breakpoint.h"
+
+#include <cstdint>
+#include <utility>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "src/agent/class_metadata_reader.h"
+#include "src/agent/format_queue.h"
+#include "src/agent/instance_field_reader.h"
+#include "src/agent/jni_utils.h"
+#include "src/agent/jvm_evaluators.h"
+#include "src/agent/messages.h"
+#include "src/agent/method_locals.h"
+#include "src/agent/model_json.h"
+#include "src/agent/model_util.h"
+#include "src/agent/object_evaluator.h"
+#include "src/agent/resolved_source_location.h"
+#include "src/agent/static_field_reader.h"
+#include "src/agent/statistician.h"
+#include "tests/agent/fake_jni.h"
+#include "tests/agent/json_eq_matcher.h"
+#include "tests/agent/mock_breakpoint_labels_provider.h"
+#include "tests/agent/mock_breakpoints_manager.h"
+#include "tests/agent/mock_class_indexer.h"
+#include "tests/agent/mock_class_metadata_reader.h"
+#include "tests/agent/mock_class_path_lookup.h"
+#include "tests/agent/mock_dynamic_logger.h"
+#include "tests/agent/mock_eval_call_stack.h"
+#include "tests/agent/mock_jvmti_env.h"
+#include "tests/agent/mock_object_evaluator.h"
+#include "tests/agent/mock_user_id_provider.h"
+
+ABSL_DECLARE_FLAG(int32, breakpoint_expiration_sec);
+ABSL_DECLARE_FLAG(double, max_dynamic_log_rate);
+ABSL_DECLARE_FLAG(double, max_dynamic_log_bytes_rate);
+ABSL_DECLARE_FLAG(int32, dynamic_log_quota_recovery_ms);
+
+using testing::_;
+using testing::AtMost;
+using testing::InSequence;
+using testing::Invoke;
+using testing::InvokeWithoutArgs;
+using testing::NiceMock;
+using testing::NotNull;
+using testing::Return;
+using testing::WithArg;
+
+namespace devtools {
+namespace cdbg {
+
+const jthread kBreakpointThread = reinterpret_cast<jthread>(0x725423);
+const jmethodID kAbstractMethod = reinterpret_cast<jmethodID>(0x123511235);
+const jmethodID kBreakpointMethod = reinterpret_cast<jmethodID>(0x612375234);
+
+class JvmBreakpointTest : public ::testing::Test {
+ protected:
+  JvmBreakpointTest()
+      : global_jvm_(fake_jni_.jvmti(), fake_jni_.jni()),
+        method_locals_(nullptr),
+        scheduler_([this]() { return simulated_time_sec_; }),
+        global_condition_cost_limiter_(1000000, 1000000),
+        global_dynamic_log_limiter_(1000, 0),
+        global_dynamic_log_bytes_limiter_(1000000, 1000000) {
+    evaluators_.class_path_lookup = &class_path_lookup_;
+    evaluators_.class_indexer = &class_indexer_;
+    evaluators_.eval_call_stack = &eval_call_stack_;
+    evaluators_.method_locals = &method_locals_;
+    evaluators_.class_metadata_reader = &class_metadata_reader_;
+    evaluators_.object_evaluator = &object_evaluator_;
+    evaluators_.method_caller_factory = [](Config::MethodCallQuotaType type) {
+      return nullptr;
+    };
+    evaluators_.labels_factory = []() {
+      return std::unique_ptr<BreakpointLabelsProvider>(
+          new NiceMock<MockBreakpointLabelsProvider>);
+    };
+    evaluators_.user_id_provider_factory = []() {
+      return std::unique_ptr<UserIdProvider>(new NiceMock<MockUserIdProvider>);
+    };
+  }
+
+  void SetUp() override {
+    InitializeStatisticians();
+
+    EXPECT_CALL(breakpoints_manager_, GetGlobalConditionCostLimiter())
+        .WillRepeatedly(Return(&global_condition_cost_limiter_));
+
+    EXPECT_CALL(breakpoints_manager_, GetGlobalDynamicLogLimiter())
+        .WillRepeatedly(Return(&global_dynamic_log_limiter_));
+
+    EXPECT_CALL(breakpoints_manager_, GetGlobalDynamicLogBytesLimiter())
+        .WillRepeatedly(Return(&global_dynamic_log_bytes_limiter_));
+
+    ON_CALL(breakpoints_manager_, SetJvmtiBreakpoint(_, _, _))
+        .WillByDefault(Return(true));
+
+    ON_CALL(breakpoints_manager_, ClearJvmtiBreakpoint(_, _, _))
+        .WillByDefault(Return());
+
+    ON_CALL(class_indexer_, FindClassBySignature(_))
+        .WillByDefault(Invoke([this](const std::string& class_signature) {
+          return JniLocalRef(fake_jni_.FindClassBySignature(class_signature));
+        }));
+
+    // Mocked expectations for "com/prod/MyClass1.java" class are defined
+    // in "FakeJni".
+
+    auto& myclass1_metadata =
+        fake_jni_.MutableStockClassMetadata(FakeJni::StockClass::MyClass1);
+
+    // This is an abstract method with the exact same name as the actual
+    // breakpoint method below, but with a different method signature.
+    FakeJni::MethodMetadata abstract_method;
+    abstract_method.id = kAbstractMethod;
+    abstract_method.metadata.name = "breakpointMethod";
+    abstract_method.metadata.signature = "(I)I";
+    myclass1_metadata.methods.push_back(abstract_method);
+
+    FakeJni::MethodMetadata breakpoint_method;
+    breakpoint_method.id = kBreakpointMethod;
+    breakpoint_method.metadata.name = "breakpointMethod";
+    breakpoint_method.metadata.signature = "()V";
+    breakpoint_method.line_number_table.push_back({100370, 370});
+    breakpoint_method.line_number_table.push_back({100371, 371});
+    breakpoint_method.line_number_table.push_back({100372, 372});
+    myclass1_metadata.methods.push_back(breakpoint_method);
+
+    ON_CALL(class_path_lookup_,
+            ResolveSourceLocation("com/prod/MyClass1.java", 371, NotNull()))
+        .WillByDefault(WithArg<2>(Invoke([](ResolvedSourceLocation* loc) {
+          loc->error_message = FormatMessageModel();
+          loc->class_signature = "Lcom/prod/MyClass1;";
+          loc->method_name = "breakpointMethod";
+          loc->method_signature = "()V";
+          loc->adjusted_line_number = 371;
+        })));
+
+    breakpoint_template_ = BreakpointBuilder()
+                               .set_id("test_breakpoint_id")
+                               .set_location("com/prod/MyClass1.java", 371)
+                               .build();
+  }
+
+  void TearDown() override {
+    // Breakpoint cleanup.
+    jvm_breakpoint_->ResetToPending();
+
+    format_queue_.RemoveAll();
+
+    CleanupStatisticians();
+  }
+
+  void Create(std::unique_ptr<BreakpointModel> breakpoint_definition) {
+    jvm_breakpoint_ = std::make_shared<JvmBreakpoint>(
+        &scheduler_, &evaluators_, &format_queue_, &dynamic_logger_,
+        &breakpoints_manager_,
+        nullptr,  // setup_error
+        std::move(breakpoint_definition));
+
+    jvm_breakpoint_->Initialize();
+  }
+
+  void ExpectNotLoadedClassLookup(const std::string& not_loaded_class) {
+    // JvmReadersFactory::FindClassByName() will try loading the class in
+    // the following ways:
+    EXPECT_CALL(class_indexer_, FindClassByName(not_loaded_class))
+        .WillOnce(
+            Invoke([](const std::string& _) { return JniLocalRef(nullptr); }));
+    EXPECT_CALL(class_indexer_,
+                FindClassByName("java.lang." + not_loaded_class))
+        .WillOnce(
+            Invoke([](const std::string& _) { return JniLocalRef(nullptr); }));
+    EXPECT_CALL(class_path_lookup_, FindClassesByName(not_loaded_class))
+        .WillOnce(Invoke([not_loaded_class](const std::string& _) {
+          return std::vector<std::string>{not_loaded_class};
+        }));
+
+    // GetMethodDeclaringClass would be called multiple times in compilation to
+    // examine various types of grammar statements.
+    ON_CALL(*((MockJvmtiEnv*)fake_jni_.jvmti()), GetMethodDeclaringClass(_, _))
+        .WillByDefault(Return(JVMTI_ERROR_NOT_FOUND));
+  }
+
+ protected:
+  FakeJni fake_jni_;
+  GlobalJvmEnv global_jvm_;
+  std::unique_ptr<Config> config_ = Config::Builder().Build();
+  NiceMock<MockClassPathLookup> class_path_lookup_;
+  NiceMock<MockClassIndexer> class_indexer_;
+  NiceMock<MockEvalCallStack> eval_call_stack_;
+  MethodLocals method_locals_;
+  MockClassMetadataReader class_metadata_reader_;
+  NiceMock<MockObjectEvaluator> object_evaluator_;
+  JvmEvaluators evaluators_;
+  FormatQueue format_queue_;
+  NiceMock<MockDynamicLogger> dynamic_logger_;
+  Scheduler<> scheduler_;
+  LeakyBucket global_condition_cost_limiter_;
+  LeakyBucket global_dynamic_log_limiter_;
+  LeakyBucket global_dynamic_log_bytes_limiter_;
+  NiceMock<MockBreakpointsManager> breakpoints_manager_;
+  std::shared_ptr<JvmBreakpoint> jvm_breakpoint_;
+
+  // Simulated absolute time (in seconds).
+  time_t simulated_time_sec_{1000000};
+
+  // Breakpoint template used throughout this test. Each test case slightly
+  // modifies the breakpoint definition. Having this template spares each
+  // test case to repeat the entire definition over and over again.
+  std::unique_ptr<BreakpointModel> breakpoint_template_;
+};
+
+TEST_F(JvmBreakpointTest, NullSourceLocation) {
+  EXPECT_CALL(breakpoints_manager_, SetJvmtiBreakpoint(_, _, _)).Times(0);
+
+  EXPECT_CALL(breakpoints_manager_, CompleteBreakpoint("test_breakpoint_id"))
+      .WillOnce(Return());
+
+  Create(
+      BreakpointBuilder(*breakpoint_template_).set_location(nullptr).build());
+
+  auto result = format_queue_.FormatAndPop();
+  ASSERT_NE(nullptr, result);
+
+  EXPECT_TRUE(result->status->is_error);
+  EXPECT_NE("", result->status->description.format);
+}
+
+TEST_F(JvmBreakpointTest, InvalidSourceLocation) {
+  EXPECT_CALL(class_path_lookup_,
+              ResolveSourceLocation("com/prod/MyClass1.java", 371, NotNull()))
+      .WillRepeatedly(WithArg<2>(Invoke([](ResolvedSourceLocation* loc) {
+        loc->error_message = {"something not found"};
+      })));
+
+  EXPECT_CALL(breakpoints_manager_, SetJvmtiBreakpoint(_, _, _)).Times(0);
+
+  Create(BreakpointBuilder(*breakpoint_template_).build());
+
+  auto result = format_queue_.FormatAndPop();
+  ASSERT_NE(nullptr, result);
+
+  EXPECT_TRUE(result->status->is_error);
+  EXPECT_EQ("something not found", result->status->description.format);
+}
+
+TEST_F(JvmBreakpointTest, DeferredBreakpoint) {
+  EXPECT_CALL(class_path_lookup_,
+              ResolveSourceLocation("com/prod/MyClass1.java", 371, NotNull()))
+      .WillRepeatedly(WithArg<2>(Invoke([](ResolvedSourceLocation* loc) {
+        loc->error_message = FormatMessageModel();
+        loc->class_signature = "Lcom/prod/ClassThatHasntBeenLoadedYet;";
+        loc->method_name = "breakpointMethod";
+        loc->method_signature = "()V";
+        loc->adjusted_line_number = 371;
+      })));
+
+  EXPECT_CALL(breakpoints_manager_, SetJvmtiBreakpoint(_, _, _)).Times(0);
+
+  Create(BreakpointBuilder(*breakpoint_template_).build());
+
+  EXPECT_EQ(nullptr, format_queue_.FormatAndPop());
+}
+TEST_F(JvmBreakpointTest, DeferredBreakpointWithCondition) {
+  // To examine the existence of class A.B.C, the compilation
+  // will break it down and look for A, and then A.B, and then A.B.C, in order
+  // to identify potential nested class.
+  ExpectNotLoadedClassLookup("com");
+  ExpectNotLoadedClassLookup("com.prod");
+  ExpectNotLoadedClassLookup("com.prod.NotLoadedClass");
+
+  EXPECT_CALL(breakpoints_manager_, SetJvmtiBreakpoint(_, _, _)).Times(0);
+
+  Create(BreakpointBuilder(*breakpoint_template_)
+             .set_condition("com.prod.NotLoadedClass.method()")
+             .build());
+
+  EXPECT_EQ(nullptr, format_queue_.FormatAndPop());
+}
+TEST_F(JvmBreakpointTest, ImmediateBreakpoint) {
+  Create(BreakpointBuilder(*breakpoint_template_).build());
+
+  EXPECT_EQ(nullptr, format_queue_.FormatAndPop());
+}
+
+TEST_F(JvmBreakpointTest, ClassPreparedOnDeferredBreakpoint) {
+  // Simulate class not loaded.
+  EXPECT_CALL(class_indexer_, FindClassBySignature(_))
+      .WillRepeatedly(InvokeWithoutArgs([]() { return nullptr; }));
+
+  Create(BreakpointBuilder(*breakpoint_template_).build());
+
+  // The class is loaded from here on.
+  EXPECT_CALL(class_indexer_, FindClassBySignature(_))
+      .WillRepeatedly(Invoke([this](const std::string& class_signature) {
+        return JniLocalRef(fake_jni_.FindClassBySignature(class_signature));
+      }));
+
+  // Not the type we need, has no effect.
+  jvm_breakpoint_->OnClassPrepared("com.prod.MyClass2", "Lcom/prod/MyClass2;");
+
+  EXPECT_CALL(breakpoints_manager_, SetJvmtiBreakpoint(_, _, _)).Times(1);
+
+  jvm_breakpoint_->OnClassPrepared("com.prod.MyClass1", "Lcom/prod/MyClass1;");
+}
+
+// This situation shouldn't normally happen. We simulate that
+// "ClassPathLookup.resolveSourceLocation" successfully mapped the source line
+// to a method, but when this method is loaded, the function that
+// "ClassPathLookup" found isn't there.
+TEST_F(JvmBreakpointTest, SourceResolutionMismatch_MissingMethod) {
+  auto& myclass1_metadata =
+      fake_jni_.MutableStockClassMetadata(FakeJni::StockClass::MyClass1);
+  myclass1_metadata.methods.clear();
+
+  Create(BreakpointBuilder(*breakpoint_template_).build());
+
+  // Verify only one hit result with error.
+  auto result = format_queue_.FormatAndPop();
+  ASSERT_NE(nullptr, result);
+  EXPECT_TRUE(result->is_final_state);
+  EXPECT_EQ(INTERNAL_ERROR_MESSAGE.format, result->status->description.format);
+
+  EXPECT_EQ(nullptr, format_queue_.FormatAndPop());
+}
+
+// Same as "SourceResolutionMismatch_MissingMethod", but with wrong line.
+TEST_F(JvmBreakpointTest, SourceResolutionMismatch_BadLine) {
+  auto& myclass1_metadata =
+      fake_jni_.MutableStockClassMetadata(FakeJni::StockClass::MyClass1);
+  myclass1_metadata.methods[1].line_number_table.clear();
+
+  Create(BreakpointBuilder(*breakpoint_template_).build());
+
+  // Verify only one hit result with error.
+  auto result = format_queue_.FormatAndPop();
+  ASSERT_NE(nullptr, result);
+  EXPECT_TRUE(result->is_final_state);
+  EXPECT_EQ(INTERNAL_ERROR_MESSAGE.format, result->status->description.format);
+
+  EXPECT_EQ(nullptr, format_queue_.FormatAndPop());
+}
+
+TEST_F(JvmBreakpointTest, Condition_Match) {
+  Create(
+      BreakpointBuilder(*breakpoint_template_).set_condition("2 < 3").build());
+
+  jvm_breakpoint_->OnJvmBreakpointHit(kBreakpointThread, kBreakpointMethod,
+                                      100371);
+
+  // Verify only one hit result.
+  auto result = format_queue_.FormatAndPop();
+  ASSERT_NE(nullptr, result);
+  ASSERT_EQ(nullptr, result->status);
+
+  EXPECT_EQ(nullptr, format_queue_.FormatAndPop());
+}
+
+TEST_F(JvmBreakpointTest, Condition_NoMatch) {
+  Create(
+      BreakpointBuilder(*breakpoint_template_).set_condition("2 > 3").build());
+
+  jvm_breakpoint_->OnJvmBreakpointHit(kBreakpointThread, kBreakpointMethod,
+                                      100371);
+
+  // Verify no hit results.
+  EXPECT_EQ(nullptr, format_queue_.FormatAndPop());
+}
+
+TEST_F(JvmBreakpointTest, BadCondition) {
+  const struct {
+    std::string condition;
+    FormatMessageModel expected_error;
+  } test_cases[] = {{// Syntax error.
+                     "2 + (4 -",
+                     {ExpressionParserError}},
+                    {// Not a boolean condition.
+                     "2 + 3",
+                     {ConditionNotBoolean, {"int"}}}};
+
+  // Not expecting "SetBreakpoint" JVMTI call due to invalid expression.
+  EXPECT_CALL(breakpoints_manager_, SetJvmtiBreakpoint(_, _, _)).Times(0);
+
+  for (const auto& test_case : test_cases) {
+    LOG(INFO) << "Testing bad condition '" << test_case.condition << "'";
+
+    Create(BreakpointBuilder(*breakpoint_template_)
+               .set_condition(test_case.condition)
+               .build());
+
+    // Verify only one final hit result (breakpoint failed to set).
+    ExpectJsonEq(
+        *BreakpointBuilder(*breakpoint_template_)
+             .set_is_final_state(true)
+             .set_condition(test_case.condition)
+             .set_status(
+                 StatusMessageBuilder()
+                     .set_error()
+                     .set_refers_to(
+                         StatusMessageModel::Context::BREAKPOINT_CONDITION)
+                     .set_description(test_case.expected_error)
+                     .build())
+             .build(),
+        format_queue_.FormatAndPop().get());
+
+    EXPECT_EQ(nullptr, format_queue_.FormatAndPop());
+  }
+}
+
+TEST_F(JvmBreakpointTest, WatchedExpressions) {
+  Create(BreakpointBuilder(*breakpoint_template_)
+             .set_expressions({"2+3", "3.14*2"})
+             .build());
+
+  jvm_breakpoint_->OnJvmBreakpointHit(kBreakpointThread, kBreakpointMethod,
+                                      100371);
+
+  // Verify only one hit result.
+  ExpectJsonEq(
+      *BreakpointBuilder(*breakpoint_template_)
+           .set_is_final_state(true)
+           .set_expressions({"2+3", "3.14*2"})
+           .add_evaluated_expression(
+               VariableBuilder().set_name("2+3").set_value("5").set_type("int"))
+           .add_evaluated_expression(
+               VariableBuilder().set_name("3.14*2").set_value("6.28").set_type(
+                   "double"))
+           .add_capture_buffer_full_variable_table_item()
+           .build(),
+      format_queue_.FormatAndPop().get());
+
+  EXPECT_EQ(nullptr, format_queue_.FormatAndPop());
+}
+
+TEST_F(JvmBreakpointTest, InterimBreakpointResults_BadExpression) {
+  Create(BreakpointBuilder(*breakpoint_template_)
+             .set_expressions({
+                 "2+3",    // Valid expression.
+                 "3.14*("  // Expression with syntax error.
+             })
+             .build());
+
+  // Verify interim breakpoint update.
+  auto result = format_queue_.FormatAndPop();
+  ExpectJsonEq(*BreakpointBuilder(*breakpoint_template_)
+                    .set_expressions({"2+3", "3.14*("})
+                    .add_evaluated_expression(
+                        VariableBuilder().set_name("2+3").set_value(""))
+                    .add_evaluated_expression(
+                        VariableBuilder().set_name("3.14*(").set_status(
+                            StatusMessageBuilder()
+                                .set_error()
+                                .set_refers_to(
+                                    StatusMessageModel::Context::VARIABLE_NAME)
+                                .set_format(ExpressionParserError)
+                                .build()))
+                    .set_is_final_state(false)
+                    .build(),
+               result.get());
+
+  EXPECT_EQ(nullptr, format_queue_.FormatAndPop());
+
+  // Now simulate breakpoint hit.
+  jvm_breakpoint_->OnJvmBreakpointHit(kBreakpointThread, kBreakpointMethod,
+                                      100371);
+
+  // Verify only one hit result.
+  ExpectJsonEq(
+      *BreakpointBuilder(*breakpoint_template_)
+           .set_is_final_state(true)
+           .set_expressions({"2+3", "3.14*("})
+           .add_evaluated_expression(
+               VariableBuilder().set_name("2+3").set_value("5").set_type("int"))
+           .add_evaluated_expression(
+               VariableBuilder().set_name("3.14*(").set_status(
+                   StatusMessageBuilder()
+                       .set_error()
+                       .set_refers_to(
+                           StatusMessageModel::Context::VARIABLE_NAME)
+                       .set_format(ExpressionParserError)
+                       .build()))
+           .add_capture_buffer_full_variable_table_item()
+           .build(),
+      format_queue_.FormatAndPop().get());
+
+  EXPECT_EQ(nullptr, format_queue_.FormatAndPop());
+}
+
+TEST_F(JvmBreakpointTest, ClassNotLoadedWhenInsert_BadExpression) {
+  ExpectNotLoadedClassLookup("NotLoadedClass");
+
+  EXPECT_CALL(breakpoints_manager_, SetJvmtiBreakpoint(_, _, _)).Times(0);
+
+  // Create a new breakpoint and evaluate the expressions.
+  // The breakpoint should remain pending.
+  Create(BreakpointBuilder(*breakpoint_template_)
+             .set_expressions({
+                 "2+3",                      // Valid expression
+                 "NotLoadedClass.SomeField"  // Expression that references
+                                             // an unloaded class.
+             })
+             .build());
+
+  // Breakpoint remains pending, so nothing in queue.
+  EXPECT_EQ(nullptr, format_queue_.FormatAndPop());
+}
+
+TEST_F(JvmBreakpointTest, LineNumberAdjustment) {
+  EXPECT_CALL(class_path_lookup_,
+              ResolveSourceLocation("com/prod/MyClass1.java", 371, NotNull()))
+      .WillRepeatedly(WithArg<2>(Invoke([](ResolvedSourceLocation* loc) {
+        loc->error_message = FormatMessageModel();
+        loc->class_signature = "Lcom/prod/MyClass1;";
+        loc->method_name = "breakpointMethod";
+        loc->method_signature = "()V";
+        loc->adjusted_line_number = 372;
+      })));
+
+  EXPECT_CALL(breakpoints_manager_,
+              SetJvmtiBreakpoint(kBreakpointMethod, 100372, _))
+      .WillOnce(Return(true));
+
+  Create(BreakpointBuilder(*breakpoint_template_).build());
+
+  // Expect interim result saying that the breakpoint moved.
+  ExpectJsonEq(*BreakpointBuilder(*breakpoint_template_)
+                    .set_location("com/prod/MyClass1.java", 372)
+                    .build(),
+               format_queue_.FormatAndPop().get());
+
+  // Simulate breakpoint hit.
+  EXPECT_CALL(breakpoints_manager_,
+              ClearJvmtiBreakpoint(kBreakpointMethod, 100372, _))
+      .WillOnce(Return());
+
+  jvm_breakpoint_->OnJvmBreakpointHit(kBreakpointThread, kBreakpointMethod,
+                                      100372);
+
+  ExpectJsonEq(*BreakpointBuilder(*breakpoint_template_)
+                    .set_is_final_state(true)
+                    .set_location("com/prod/MyClass1.java", 372)
+                    .add_capture_buffer_full_variable_table_item()
+                    .build(),
+               format_queue_.FormatAndPop().get());
+
+  EXPECT_EQ(nullptr, format_queue_.FormatAndPop());
+}
+
+TEST_F(JvmBreakpointTest, BreakpointExpirationWithCreatedTime) {
+  Create(BreakpointBuilder(*breakpoint_template_)
+             .set_create_time(TimestampBuilder::Build(simulated_time_sec_))
+             .build());
+
+  EXPECT_CALL(breakpoints_manager_, CompleteBreakpoint("test_breakpoint_id"))
+      .WillOnce(Return());
+
+  simulated_time_sec_ += absl::GetFlag(FLAGS_breakpoint_expiration_sec);
+  scheduler_.Process();
+}
+
+TEST_F(JvmBreakpointTest, BreakpointExpirationNoCreatedTime) {
+  Create(BreakpointBuilder(*breakpoint_template_).build());
+
+  simulated_time_sec_ += absl::GetFlag(FLAGS_breakpoint_expiration_sec) - 1;
+  scheduler_.Process();
+
+  EXPECT_CALL(breakpoints_manager_, CompleteBreakpoint("test_breakpoint_id"))
+      .WillOnce(Return());
+
+  simulated_time_sec_ += 2;
+  scheduler_.Process();
+}
+
+TEST_F(JvmBreakpointTest, BreakpointExpirationWithExpiresIn) {
+  Create(BreakpointBuilder(*breakpoint_template_)
+             .set_create_time(TimestampBuilder::Build(simulated_time_sec_))
+             .set_expires_in(DurationBuilder::Build(10))
+             .build());
+
+  simulated_time_sec_ += 9;
+  scheduler_.Process();
+
+  EXPECT_CALL(breakpoints_manager_, CompleteBreakpoint("test_breakpoint_id"))
+      .WillOnce(Return());
+
+  simulated_time_sec_ += 2;
+  scheduler_.Process();
+}
+
+TEST_F(JvmBreakpointTest, BreakpointExpirationWithTruncatedExpiresIn) {
+  Create(BreakpointBuilder(*breakpoint_template_)
+             .set_create_time(TimestampBuilder::Build(simulated_time_sec_))
+             .set_expires_in(DurationBuilder::Build(
+                 // Values higher than the expiration sec flag are truncated.
+                 absl::GetFlag(FLAGS_breakpoint_expiration_sec) + 10))
+             .build());
+
+  EXPECT_CALL(breakpoints_manager_, CompleteBreakpoint("test_breakpoint_id"))
+      .WillOnce(Return());
+
+  simulated_time_sec_ += absl::GetFlag(FLAGS_breakpoint_expiration_sec);
+  scheduler_.Process();
+}
+
+TEST_F(JvmBreakpointTest, BreakpointExpirationWithNegativeExpiresIn) {
+  Create(BreakpointBuilder(*breakpoint_template_)
+             .set_create_time(TimestampBuilder::Build(simulated_time_sec_))
+             .set_expires_in(DurationBuilder::Build(-1))
+             .build());
+
+  EXPECT_CALL(breakpoints_manager_, CompleteBreakpoint("test_breakpoint_id"))
+      .WillOnce(Return());
+
+  scheduler_.Process();
+}
+
+TEST_F(JvmBreakpointTest, DynamicLoggerNotAvailable) {
+  Create(BreakpointBuilder(*breakpoint_template_)
+             .set_action(BreakpointModel::Action::LOG)
+             .build());
+
+  EXPECT_CALL(dynamic_logger_, IsAvailable()).WillRepeatedly(Return(false));
+
+  EXPECT_CALL(breakpoints_manager_, CompleteBreakpoint("test_breakpoint_id"))
+      .WillOnce(Return());
+
+  jvm_breakpoint_->OnJvmBreakpointHit(kBreakpointThread, kBreakpointMethod,
+                                      100371);
+}
+
+TEST_F(JvmBreakpointTest, DynamicLoggerNoParameters) {
+  Create(BreakpointBuilder(*breakpoint_template_)
+             .set_action(BreakpointModel::Action::LOG)
+             .set_log_level(BreakpointModel::LogLevel::WARNING)
+             .set_log_message_format("hello there")
+             .build());
+
+  EXPECT_CALL(dynamic_logger_, Log(BreakpointModel::LogLevel::WARNING, _,
+                                   "LOGPOINT: hello there"))
+      .WillOnce(WithArg<1>(Invoke([](const ResolvedSourceLocation& rsl) {
+        EXPECT_EQ("", rsl.error_message.format);
+        EXPECT_EQ("Lcom/prod/MyClass1;", rsl.class_signature);
+        EXPECT_EQ("breakpointMethod", rsl.method_name);
+        EXPECT_EQ(371, rsl.adjusted_line_number);
+      })));
+
+  jvm_breakpoint_->OnJvmBreakpointHit(kBreakpointThread, kBreakpointMethod,
+                                      100371);
+}
+
+TEST_F(JvmBreakpointTest, DynamicLoggerWithParameters) {
+  Create(BreakpointBuilder(*breakpoint_template_)
+             .set_action(BreakpointModel::Action::LOG)
+             .set_log_level(BreakpointModel::LogLevel::WARNING)
+             .set_log_message_format("$0 should be 56 and $1 should be 36")
+             .add_expression("7 * 8")
+             .add_expression("6 * 6")
+             .build());
+
+  EXPECT_CALL(dynamic_logger_,
+              Log(BreakpointModel::LogLevel::WARNING, _,
+                  "LOGPOINT: 56 should be 56 and 36 should be 36"))
+      .Times(1);
+
+  jvm_breakpoint_->OnJvmBreakpointHit(kBreakpointThread, kBreakpointMethod,
+                                      100371);
+}
+
+TEST_F(JvmBreakpointTest, DynamicLogQuotaExceededAfterSuccess) {
+  // Initialize the global quota to only allow one log message ever.
+  LeakyBucket global_quota(1, 0);
+  EXPECT_CALL(breakpoints_manager_, GetGlobalDynamicLogLimiter())
+      .WillRepeatedly(Return(&global_quota));
+
+  Create(BreakpointBuilder(*breakpoint_template_)
+             .set_action(BreakpointModel::Action::LOG)
+             .set_log_level(BreakpointModel::LogLevel::WARNING)
+             .set_log_message_format("log worked")
+             .build());
+
+  {
+    InSequence sequence;
+
+    EXPECT_CALL(dynamic_logger_, Log(BreakpointModel::LogLevel::WARNING, _,
+                                     "LOGPOINT: log worked"))
+        .Times(1);
+
+    EXPECT_CALL(dynamic_logger_,
+                Log(BreakpointModel::LogLevel::WARNING, _,
+                    std::string("LOGPOINT: ") + DynamicLogOutOfCallQuota))
+        .Times(1);
+  }
+
+  for (int i = 0; i < 100; ++i) {
+    jvm_breakpoint_->OnJvmBreakpointHit(kBreakpointThread, kBreakpointMethod,
+                                        100371);
+  }
+}
+
+TEST_F(JvmBreakpointTest, DynamicLogBytesQuotaExceededAfterSuccess) {
+  // Initialize the global quota to only allow one log message ever.
+  LeakyBucket global_bytes_quota(arraysize("LOGPOINT: log worked"), 0);
+  EXPECT_CALL(breakpoints_manager_, GetGlobalDynamicLogBytesLimiter())
+      .WillRepeatedly(Return(&global_bytes_quota));
+
+  Create(BreakpointBuilder(*breakpoint_template_)
+             .set_action(BreakpointModel::Action::LOG)
+             .set_log_level(BreakpointModel::LogLevel::WARNING)
+             .set_log_message_format("log worked")
+             .build());
+
+  {
+    InSequence sequence;
+
+    EXPECT_CALL(dynamic_logger_, Log(BreakpointModel::LogLevel::WARNING, _,
+                                     "LOGPOINT: log worked"))
+        .Times(1);
+
+    EXPECT_CALL(dynamic_logger_,
+                Log(BreakpointModel::LogLevel::WARNING, _,
+                    std::string("LOGPOINT: ") + DynamicLogOutOfBytesQuota))
+        .Times(1);
+  }
+
+  for (int i = 0; i < 100; ++i) {
+    jvm_breakpoint_->OnJvmBreakpointHit(kBreakpointThread, kBreakpointMethod,
+                                        100371);
+  }
+}
+
+TEST_F(JvmBreakpointTest, DynamicLogQuotaExceededOnFirstLog) {
+  LeakyBucket global_quota(0, 0);
+  EXPECT_CALL(breakpoints_manager_, GetGlobalDynamicLogLimiter())
+      .WillRepeatedly(Return(&global_quota));
+
+  Create(BreakpointBuilder(*breakpoint_template_)
+             .set_action(BreakpointModel::Action::LOG)
+             .set_log_level(BreakpointModel::LogLevel::WARNING)
+             .set_log_message_format("this is unexpected")
+             .build());
+
+  EXPECT_CALL(dynamic_logger_,
+              Log(BreakpointModel::LogLevel::WARNING, _,
+                  std::string("LOGPOINT: ") + DynamicLogOutOfCallQuota))
+      .Times(1);
+
+  for (int i = 0; i < 10; ++i) {
+    jvm_breakpoint_->OnJvmBreakpointHit(kBreakpointThread, kBreakpointMethod,
+                                        100371);
+  }
+}
+
+TEST_F(JvmBreakpointTest, DynamicLogBytesQuotaExceededOnFirstLog) {
+  LeakyBucket global_bytes_quota(0, 0);
+  EXPECT_CALL(breakpoints_manager_, GetGlobalDynamicLogBytesLimiter())
+      .WillRepeatedly(Return(&global_bytes_quota));
+
+  Create(BreakpointBuilder(*breakpoint_template_)
+             .set_action(BreakpointModel::Action::LOG)
+             .set_log_level(BreakpointModel::LogLevel::WARNING)
+             .set_log_message_format("this is unexpected")
+             .build());
+
+  EXPECT_CALL(dynamic_logger_,
+              Log(BreakpointModel::LogLevel::WARNING, _,
+                  std::string("LOGPOINT: ") + DynamicLogOutOfBytesQuota))
+      .Times(1);
+
+  for (int i = 0; i < 10; ++i) {
+    jvm_breakpoint_->OnJvmBreakpointHit(kBreakpointThread, kBreakpointMethod,
+                                        100371);
+  }
+}
+
+TEST_F(JvmBreakpointTest, DynamicLogQuotaRecovery) {
+  // Initialize the global quota to only allow one log message ever.
+  LeakyBucket global_quota(0, 0);
+  EXPECT_CALL(breakpoints_manager_, GetGlobalDynamicLogLimiter())
+      .Times(1)
+      .WillRepeatedly(Return(&global_quota))
+      .RetiresOnSaturation();
+
+  Create(BreakpointBuilder(*breakpoint_template_)
+             .set_action(BreakpointModel::Action::LOG)
+             .set_log_level(BreakpointModel::LogLevel::WARNING)
+             .set_log_message_format("log worked")
+             .build());
+
+  {
+    InSequence sequence;
+
+    EXPECT_CALL(dynamic_logger_,
+                Log(BreakpointModel::LogLevel::WARNING, _,
+                    std::string("LOGPOINT: ") + DynamicLogOutOfCallQuota))
+        .Times(1);
+
+    EXPECT_CALL(dynamic_logger_, Log(BreakpointModel::LogLevel::WARNING, _,
+                                     "LOGPOINT: log worked"))
+        .Times(3);
+  }
+
+  for (int i = 0; i < 5; ++i) {
+    jvm_breakpoint_->OnJvmBreakpointHit(kBreakpointThread, kBreakpointMethod,
+                                        100371);
+  }
+
+  usleep((absl::GetFlag(FLAGS_dynamic_log_quota_recovery_ms) + 50) * 1000);
+
+  for (int i = 0; i < 3; ++i) {
+    jvm_breakpoint_->OnJvmBreakpointHit(kBreakpointThread, kBreakpointMethod,
+                                        100371);
+  }
+}
+
+TEST_F(JvmBreakpointTest, DynamicLogBytesQuotaRecovery) {
+  // Initialize the global bytes quota to only allow one log message ever.
+  LeakyBucket global_bytes_quota(0, 0);
+  EXPECT_CALL(breakpoints_manager_, GetGlobalDynamicLogBytesLimiter())
+      .Times(1)
+      .WillRepeatedly(Return(&global_bytes_quota))
+      .RetiresOnSaturation();
+
+  Create(BreakpointBuilder(*breakpoint_template_)
+             .set_action(BreakpointModel::Action::LOG)
+             .set_log_level(BreakpointModel::LogLevel::WARNING)
+             .set_log_message_format("log worked")
+             .build());
+
+  {
+    InSequence sequence;
+
+    EXPECT_CALL(dynamic_logger_,
+                Log(BreakpointModel::LogLevel::WARNING, _,
+                    std::string("LOGPOINT: ") + DynamicLogOutOfBytesQuota))
+        .Times(1);
+
+    EXPECT_CALL(dynamic_logger_, Log(BreakpointModel::LogLevel::WARNING, _,
+                                     "LOGPOINT: log worked"))
+        .Times(3);
+  }
+
+  for (int i = 0; i < 5; ++i) {
+    jvm_breakpoint_->OnJvmBreakpointHit(kBreakpointThread, kBreakpointMethod,
+                                        100371);
+  }
+
+  usleep((absl::GetFlag(FLAGS_dynamic_log_quota_recovery_ms) + 50) * 1000);
+
+  for (int i = 0; i < 3; ++i) {
+    jvm_breakpoint_->OnJvmBreakpointHit(kBreakpointThread, kBreakpointMethod,
+                                        100371);
+  }
+}
+
+TEST_F(JvmBreakpointTest, DynamicLogPerBreakpointQuotaExceeded) {
+  absl::FlagSaver fs;
+
+  absl::SetFlag(&FLAGS_max_dynamic_log_rate, 2);
+
+  Create(BreakpointBuilder(*breakpoint_template_)
+             .set_action(BreakpointModel::Action::LOG)
+             .set_log_level(BreakpointModel::LogLevel::WARNING)
+             .set_log_message_format("log worked")
+             .build());
+
+  {
+    InSequence sequence;
+
+    EXPECT_CALL(dynamic_logger_, Log(BreakpointModel::LogLevel::WARNING, _,
+                                     "LOGPOINT: log worked"))
+        .Times(AtMost(30));
+
+    EXPECT_CALL(dynamic_logger_,
+                Log(BreakpointModel::LogLevel::WARNING, _,
+                    std::string("LOGPOINT: ") + DynamicLogOutOfCallQuota))
+        .Times(1);
+  }
+
+  for (int i = 0; i < 100; ++i) {
+    jvm_breakpoint_->OnJvmBreakpointHit(kBreakpointThread, kBreakpointMethod,
+                                        100371);
+  }
+}
+
+TEST_F(JvmBreakpointTest, DynamicLogBytesPerBreakpointQuotaExceeded) {
+  absl::FlagSaver fs;
+
+  // Use 100 bytes per second, which should allow at most 4-5 log lines before
+  // hitting the quota.
+  absl::SetFlag(&FLAGS_max_dynamic_log_bytes_rate, 100);
+
+  Create(BreakpointBuilder(*breakpoint_template_)
+             .set_action(BreakpointModel::Action::LOG)
+             .set_log_level(BreakpointModel::LogLevel::WARNING)
+             .set_log_message_format("log worked")
+             .build());
+
+  {
+    InSequence sequence;
+
+    EXPECT_CALL(dynamic_logger_, Log(BreakpointModel::LogLevel::WARNING, _,
+                                     "LOGPOINT: log worked"))
+        .Times(AtMost(30));
+
+    EXPECT_CALL(dynamic_logger_,
+                Log(BreakpointModel::LogLevel::WARNING, _,
+                    std::string("LOGPOINT: ") + DynamicLogOutOfBytesQuota))
+        .Times(1);
+  }
+
+  for (int i = 0; i < 100; ++i) {
+    jvm_breakpoint_->OnJvmBreakpointHit(kBreakpointThread, kBreakpointMethod,
+                                        100371);
+  }
+}
+
+TEST_F(JvmBreakpointTest, PreemptiveStatusSet) {
+  std::unique_ptr<StatusMessageModel> setup_error =
+      StatusMessageBuilder().set_error().set_format("test format").build();
+
+  jvm_breakpoint_ = std::make_shared<JvmBreakpoint>(
+      &scheduler_, &evaluators_, &format_queue_, &dynamic_logger_,
+      &breakpoints_manager_, std::move(setup_error),
+      BreakpointBuilder(*breakpoint_template_).build());
+
+  jvm_breakpoint_->Initialize();
+
+  auto result = format_queue_.FormatAndPop();
+  ASSERT_NE(nullptr, result);
+
+  EXPECT_TRUE(result->status->is_error);
+  EXPECT_EQ("test format", result->status->description.format);
+}
+
+}  // namespace cdbg
+}  // namespace devtools

--- a/tests/agent/jvm_breakpoints_manager_test.cc
+++ b/tests/agent/jvm_breakpoints_manager_test.cc
@@ -1,0 +1,675 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/agent/jvm_breakpoints_manager.h"
+
+#include "gtest/gtest.h"
+#include "src/agent/callbacks_monitor.h"
+#include "src/agent/format_queue.h"
+#include "src/agent/jvm_evaluators.h"
+#include "src/agent/messages.h"
+#include "src/agent/method_locals.h"
+#include "src/agent/model_util.h"
+#include "src/agent/object_evaluator.h"
+#include "src/agent/resolved_source_location.h"
+#include "src/agent/statistician.h"
+#include "tests/agent/fake_jni.h"
+#include "tests/agent/mock_breakpoint.h"
+#include "tests/agent/mock_bridge.h"
+#include "tests/agent/mock_class_indexer.h"
+#include "tests/agent/mock_class_metadata_reader.h"
+#include "tests/agent/mock_class_path_lookup.h"
+#include "tests/agent/mock_dynamic_logger.h"
+#include "tests/agent/mock_eval_call_stack.h"
+#include "tests/agent/mock_jvmti_env.h"
+#include "tests/agent/mock_object_evaluator.h"
+
+using testing::_;
+using testing::DoAll;
+using testing::Eq;
+using testing::IsNull;
+using testing::Matcher;
+using testing::MatcherInterface;
+using testing::MatchResultListener;
+using testing::NiceMock;
+using testing::NotNull;
+using testing::Test;
+using testing::Return;
+using testing::ReturnRef;
+using testing::StrictMock;
+using testing::WithArgs;
+using testing::Invoke;
+using testing::InvokeArgument;
+using testing::SetArgPointee;
+
+namespace devtools {
+namespace cdbg {
+
+static ClassMetadataReader::Method make_method(const std::string& name) {
+  ClassMetadataReader::Method metadata;
+  metadata.name = name;
+
+  return metadata;
+}
+
+static const jthread kThread = reinterpret_cast<jthread>(0x67125374);
+
+static const FakeJni::ClassMetadata kClass1Metadata = {
+    "Class1.java",                        // file_name
+    "Lcom/prod/Class1;",                  // signature
+    std::string(),                        // generic
+    {{                                    // Method
+      reinterpret_cast<jmethodID>(1001),  // id
+      make_method("firstMethod"),         // metadata.name
+      {                                   // line_number_table
+       {10031, 31},
+       {10035, 35}}}}};
+
+static const FakeJni::ClassMetadata kClass2Metadata = {
+    "Class2.java",                        // file_name
+    "Lcom/prod/Class2;",                  // signature
+    std::string(),                        // generic
+    {{                                    // Method
+      reinterpret_cast<jmethodID>(2001),  // id
+      make_method("secondMethod"),        // metadata.name
+      {                                   // line_number_table
+       {20100, 100}}}}};
+
+static const EvalCallStack::FrameInfo frame_info_keys[] = {
+    {
+        "Frame1_ClassSignature",  // class_signature
+        std::string(),            // class_generic
+        "Frame1_Method",          // method_name
+        "Frame1_SourceFileName",  // source_file_name
+        1                         // line_number
+    },
+    {
+        "Frame2_ClassSignature",  // class_signature
+        std::string(),            // class_generic
+        "Frame2_Method",          // method_name
+        "Frame2_SourceFileName",  // source_file_name
+        2                         // line_number
+    }};
+
+class JvmBreakpointsManagerTest : public ::testing::Test {
+ protected:
+  JvmBreakpointsManagerTest()
+      : fake_jni_(&jvmti_),
+        global_jvm_(fake_jni_.jvmti(), fake_jni_.jni()),
+        method_locals_(nullptr) {
+    evaluators_.class_path_lookup = &class_path_lookup_;
+    evaluators_.class_indexer = &class_indexer_;
+    evaluators_.eval_call_stack = &eval_call_stack_;
+    evaluators_.method_locals = &method_locals_;
+    evaluators_.class_metadata_reader = &class_metadata_reader_;
+    evaluators_.object_evaluator = &object_evaluator_;
+  }
+
+  MOCK_METHOD(std::shared_ptr<Breakpoint>, BreakpointFactory,
+              (const std::string&));
+
+  void SetUp() override {
+    InitializeStatisticians();
+    CallbacksMonitor::InitializeSingleton(1000);
+
+    EXPECT_CALL(class_indexer_, FindClassBySignature(_))
+        .WillRepeatedly(Invoke([this](const std::string& class_signature) {
+          return JniLocalRef(fake_jni_.FindClassBySignature(class_signature));
+        }));
+
+    // By default assume the location can't be resolved.
+    ResolvedSourceLocation bad_source_code;
+    bad_source_code.error_message = { "Bad source code" };
+
+    EXPECT_CALL(
+        class_path_lookup_,
+        ResolveSourceLocation(_, _, NotNull()))
+        .WillRepeatedly(SetArgPointee<2>(bad_source_code));
+
+    // Set up call stack.
+    EXPECT_CALL(eval_call_stack_, Read(kThread, NotNull()))
+        .WillRepeatedly(SetArgPointee<1>(std::vector<EvalCallStack::JvmFrame>({
+            { { reinterpret_cast<jmethodID>(9001), 100 }, 0 },
+            { { reinterpret_cast<jmethodID>(9002), 200 }, 1 }
+        })));
+
+    for (int i = 0; i < arraysize(frame_info_keys); ++i) {
+      EXPECT_CALL(eval_call_stack_, ResolveCallFrameKey(i))
+          .WillRepeatedly(ReturnRef(frame_info_keys[i]));
+    }
+
+    // Simulate no local variables.
+    EXPECT_CALL(jvmti_, GetMethodDeclaringClass(_, NotNull()))
+        .WillRepeatedly(DoAll(
+            SetArgPointee<1>(nullptr),
+            Return(JVMTI_ERROR_NONE)));
+
+    EXPECT_CALL(jvmti_, GetLocalVariableTable(_, NotNull(), NotNull()))
+        .WillRepeatedly(Invoke([] (
+            jmethodID method,
+            jint* entry_count,
+            jvmtiLocalVariableEntry** table) {
+          *entry_count = 0;
+          *table = reinterpret_cast<jvmtiLocalVariableEntry*>(new char[0]);
+
+          return JVMTI_ERROR_NONE;
+        }));
+
+    // Simulate static methods so that we don't need to mock extraction of
+    // local instance.
+    EXPECT_CALL(jvmti_, GetMethodModifiers(_, NotNull()))
+        .WillRepeatedly(DoAll(
+            SetArgPointee<1>(JVM_ACC_STATIC),
+            Return(JVMTI_ERROR_NONE)));
+  }
+
+  void TearDown() override {
+    EXPECT_CALL(jvmti_, ClearBreakpoint(_, _))
+        .WillRepeatedly(Return(JVMTI_ERROR_NONE));
+
+    breakpoints_manager_->Cleanup();
+
+    format_queue_.RemoveAll();
+
+    CallbacksMonitor::CleanupSingleton();
+    CleanupStatisticians();
+  }
+
+  void InitializeBreakpointsManager(CanaryControl* canary_control = nullptr) {
+    auto factory = [this] (
+        BreakpointsManager* breakpoints_manager,
+        std::unique_ptr<BreakpointModel> breakpoint_definition) {
+      EXPECT_EQ(breakpoints_manager_.get(), breakpoints_manager);
+      return BreakpointFactory(breakpoint_definition->id);
+    };
+
+    breakpoints_manager_.reset(new JvmBreakpointsManager(
+        factory,
+        &evaluators_,
+        &format_queue_,
+        canary_control));
+  }
+
+  void SetActiveBreakpointsList(
+      const std::vector<BreakpointModel*>& breakpoint_ptrs) {
+    // Clone the breakpoints list.
+    std::vector<std::unique_ptr<BreakpointModel>> breakpoints;
+    for (BreakpointModel* breakpoint : breakpoint_ptrs) {
+      breakpoints.push_back(BreakpointBuilder(*breakpoint).build());
+    }
+
+    breakpoints_manager_->SetActiveBreakpointsList(std::move(breakpoints));
+  }
+
+  void ExpectResolveSourceLocation(const std::string& source_path,
+                                   int line_number,
+                                   const std::string& resolved_class_signature,
+                                   const std::string& resolved_method_name,
+                                   int adjusted_line_number) {
+    ResolvedSourceLocation location;
+    location.class_signature = resolved_class_signature;
+    location.method_name = resolved_method_name;
+    location.adjusted_line_number = adjusted_line_number;
+
+    EXPECT_CALL(
+        class_path_lookup_,
+        ResolveSourceLocation(source_path, line_number, NotNull()))
+        .WillRepeatedly(SetArgPointee<2>(location));
+  }
+
+  void ExpectSetBreakpoint(jmethodID method, jlocation location) {
+    EXPECT_CALL(jvmti_, SetBreakpoint(method, location))
+        .WillOnce(Return(JVMTI_ERROR_NONE))
+        .RetiresOnSaturation();
+  }
+
+  void ExpectClearBreakpoint(jmethodID method, jlocation location) {
+    EXPECT_CALL(jvmti_, ClearBreakpoint(method, location))
+        .WillOnce(Return(JVMTI_ERROR_NONE))
+        .RetiresOnSaturation();
+  }
+
+
+ protected:
+  NiceMock<MockJvmtiEnv> jvmti_;
+  FakeJni fake_jni_;
+  GlobalJvmEnv global_jvm_;
+  MockClassPathLookup class_path_lookup_;
+  MockClassIndexer class_indexer_;
+  MockEvalCallStack eval_call_stack_;
+  MethodLocals method_locals_;
+  MockClassMetadataReader class_metadata_reader_;
+  NiceMock<MockObjectEvaluator> object_evaluator_;
+  JvmEvaluators evaluators_;
+  FormatQueue format_queue_;
+  MockDynamicLogger dynamic_logger_;
+  StrictMock<MockBridge> bridge_;
+  std::unique_ptr<BreakpointsManager> breakpoints_manager_;
+};
+
+
+TEST_F(JvmBreakpointsManagerTest, Empty) {
+  InitializeBreakpointsManager();
+  SetActiveBreakpointsList({});
+}
+
+
+TEST_F(JvmBreakpointsManagerTest, AddSingle) {
+  auto bp = BreakpointBuilder()
+      .set_id("ID_A")
+      .set_location("Class1.java", 31)
+      .build();
+
+  auto breakpoint = std::make_shared<NiceMock<MockBreakpoint>>("ID_A");
+  EXPECT_CALL(*this, BreakpointFactory("ID_A"))
+      .WillOnce(Return(breakpoint));
+
+  CanaryControl canary_control(CallbacksMonitor::GetInstance(), &bridge_);
+  InitializeBreakpointsManager(&canary_control);
+  SetActiveBreakpointsList({ bp.get() });
+}
+
+
+TEST_F(JvmBreakpointsManagerTest, BreakpointInitializationCallbacks) {
+  // Simulate JVMTI callbacks from within Breakpoint::Initialize to verify
+  // no deadlocks.
+  auto bp = BreakpointBuilder()
+      .set_id("ID_A")
+      .set_location("Class1.java", 32)
+      .build();
+
+  EXPECT_CALL(*this, BreakpointFactory("ID_A"))
+      .WillOnce(Invoke([this](const std::string& id) {
+        auto breakpoint = std::make_shared<NiceMock<MockBreakpoint>>(id);
+        EXPECT_CALL(*breakpoint, Initialize())
+            .WillOnce(Invoke([this] () {
+              class_indexer_.FireOnClassPrepared(
+                  "com.prod.SomeOtherClass.InnerClass",
+                  "Lcom/prod/SomeOtherClass$InnerClass;");
+            }));
+
+        return breakpoint;
+      }));
+
+  InitializeBreakpointsManager();
+  SetActiveBreakpointsList({ bp.get() });
+}
+
+
+TEST_F(JvmBreakpointsManagerTest, AddTwoBreakpointsSameLocation) {
+  auto definition1 = BreakpointBuilder()
+      .set_id("ID_A")
+      .set_location("Class1.java", 31)
+      .build();
+
+  auto definition2 = BreakpointBuilder()
+      .set_id("ID_B")
+      .set_location("Class1.java", 31)
+      .build();
+
+  std::shared_ptr<MockBreakpoint> breakpoints[] = {
+    std::make_shared<NiceMock<MockBreakpoint>>("ID_A"),
+    std::make_shared<NiceMock<MockBreakpoint>>("ID_B")
+  };
+
+  EXPECT_CALL(*this, BreakpointFactory("ID_A"))
+      .WillOnce(Return(breakpoints[0]));
+
+  EXPECT_CALL(*this, BreakpointFactory("ID_B"))
+      .WillOnce(Return(breakpoints[1]));
+
+  for (auto& breakpoint : breakpoints) {
+    EXPECT_CALL(*breakpoint, Initialize())
+        .WillOnce(Invoke([this, &breakpoint] () {
+          breakpoints_manager_->SetJvmtiBreakpoint(
+              reinterpret_cast<jmethodID>(1001),
+              10031,
+              breakpoint);
+        }))
+        .RetiresOnSaturation();
+
+    EXPECT_CALL(*breakpoint, ResetToPending())
+        .WillOnce(Invoke([this, &breakpoint] () {
+          breakpoints_manager_->ClearJvmtiBreakpoint(
+              reinterpret_cast<jmethodID>(1001),
+              10031,
+              breakpoint);
+        }))
+        .RetiresOnSaturation();
+  }
+
+  InitializeBreakpointsManager();
+
+  ExpectSetBreakpoint(reinterpret_cast<jmethodID>(1001), 10031);
+  SetActiveBreakpointsList({ definition1.get(), definition2.get() });
+
+  ExpectClearBreakpoint(reinterpret_cast<jmethodID>(1001), 10031);
+  SetActiveBreakpointsList({});
+}
+
+
+TEST_F(JvmBreakpointsManagerTest, RefreshNoChange) {
+  auto definition1 = BreakpointBuilder()
+      .set_id("ID_A")
+      .set_location("Class1.java", 31)
+      .build();
+
+  auto definition2 = BreakpointBuilder()
+      .set_id("ID_B")
+      .set_location("Class1.java", 35)
+      .build();
+
+  std::shared_ptr<MockBreakpoint> breakpoints[] = {
+    std::make_shared<NiceMock<MockBreakpoint>>("ID_A"),
+    std::make_shared<NiceMock<MockBreakpoint>>("ID_B")
+  };
+
+  EXPECT_CALL(*this, BreakpointFactory("ID_A"))
+      .WillOnce(Return(breakpoints[0]));
+
+  EXPECT_CALL(*this, BreakpointFactory("ID_B"))
+      .WillOnce(Return(breakpoints[1]));
+
+  InitializeBreakpointsManager();
+  SetActiveBreakpointsList({ definition1.get(), definition2.get() });
+  SetActiveBreakpointsList({ definition1.get(), definition2.get() });
+  SetActiveBreakpointsList({ definition2.get(), definition1.get() });
+}
+
+
+TEST_F(JvmBreakpointsManagerTest, IncrementalAdd) {
+  auto definition1 = BreakpointBuilder()
+      .set_id("ID_A")
+      .set_location("Class1.java", 31)
+      .build();
+
+  auto definition2 = BreakpointBuilder()
+      .set_id("ID_B")
+      .set_location("Class1.java", 31)
+      .build();
+
+  auto definition3 = BreakpointBuilder()
+      .set_id("ID_C")
+      .set_location("Class1.java", 35)
+      .build();
+
+  auto definition4 = BreakpointBuilder()
+      .set_id("ID_D")
+      .set_location("Class2.java", 100)
+      .build();
+
+  std::shared_ptr<MockBreakpoint> breakpoints[] = {
+    std::make_shared<NiceMock<MockBreakpoint>>("ID_A"),
+    std::make_shared<NiceMock<MockBreakpoint>>("ID_B"),
+    std::make_shared<NiceMock<MockBreakpoint>>("ID_C"),
+    std::make_shared<NiceMock<MockBreakpoint>>("ID_D")
+  };
+
+  EXPECT_CALL(*this, BreakpointFactory("ID_A"))
+      .WillOnce(Return(breakpoints[0]));
+
+  InitializeBreakpointsManager();
+
+  SetActiveBreakpointsList(
+      {
+        definition1.get()
+      });
+
+  EXPECT_CALL(*this, BreakpointFactory("ID_B"))
+      .WillOnce(Return(breakpoints[1]));
+  SetActiveBreakpointsList(
+      {
+        definition2.get(),
+        definition1.get()
+      });
+
+  EXPECT_CALL(*this, BreakpointFactory("ID_C"))
+      .WillOnce(Return(breakpoints[2]));
+  SetActiveBreakpointsList(
+      {
+        definition2.get(),
+        definition3.get(),
+        definition1.get()
+      });
+
+  EXPECT_CALL(*this, BreakpointFactory("ID_D"))
+      .WillOnce(Return(breakpoints[3]));
+  SetActiveBreakpointsList(
+      {
+        definition2.get(),
+        definition3.get(),
+        definition4.get(),
+        definition1.get()
+      });
+}
+
+
+TEST_F(JvmBreakpointsManagerTest, OnClassPreparedBroadcast) {
+  auto definition1 = BreakpointBuilder()
+      .set_id("ID_A")
+      .set_location("Class1.java", 31)
+      .build();
+
+  auto definition2 = BreakpointBuilder()
+      .set_id("ID_B")
+      .set_location("Class1.java", 35)
+      .build();
+
+  std::shared_ptr<MockBreakpoint> breakpoints[] = {
+    std::make_shared<NiceMock<MockBreakpoint>>("ID_A"),
+    std::make_shared<NiceMock<MockBreakpoint>>("ID_B")
+  };
+
+  EXPECT_CALL(*this, BreakpointFactory("ID_A"))
+      .WillOnce(Return(breakpoints[0]));
+
+  EXPECT_CALL(*this, BreakpointFactory("ID_B"))
+      .WillOnce(Return(breakpoints[1]));
+
+  InitializeBreakpointsManager();
+
+  SetActiveBreakpointsList({ definition1.get(), definition2.get() });
+
+  for (const auto& breakpoint : breakpoints) {
+    EXPECT_CALL(*breakpoint,
+                OnClassPrepared("Lcom/prod/PendingClass;", "whateverMethod"))
+        .Times(1);
+  }
+
+  class_indexer_.FireOnClassPrepared(
+      "Lcom/prod/PendingClass;",
+      "whateverMethod");
+}
+
+
+TEST_F(JvmBreakpointsManagerTest, RemovePendingBreakpoint) {
+  auto definition = BreakpointBuilder()
+      .set_id("ID_A")
+      .set_location("Class1.java", 31)
+      .build();
+
+  std::shared_ptr<MockBreakpoint> breakpoint =
+      std::make_shared<NiceMock<MockBreakpoint>>("ID_A");
+
+  EXPECT_CALL(*this, BreakpointFactory("ID_A"))
+      .WillOnce(Return(breakpoint));
+
+  InitializeBreakpointsManager();
+
+  SetActiveBreakpointsList({ definition.get() });
+
+  EXPECT_CALL(*breakpoint, ResetToPending())
+      .Times(1);
+
+  SetActiveBreakpointsList({});
+
+  EXPECT_EQ(nullptr, format_queue_.FormatAndPop());
+}
+
+
+TEST_F(JvmBreakpointsManagerTest, UnrecognizedBreakpointHit) {
+  InitializeBreakpointsManager();
+
+  breakpoints_manager_->JvmtiOnBreakpoint(
+      kThread,
+      reinterpret_cast<jmethodID>(1002),
+      10031);
+
+  breakpoints_manager_->JvmtiOnBreakpoint(
+      kThread,
+      reinterpret_cast<jmethodID>(1001),
+      10032);
+
+  EXPECT_EQ(nullptr, format_queue_.FormatAndPop());
+}
+
+
+TEST_F(JvmBreakpointsManagerTest, BreakpointHit) {
+  const jmethodID method = reinterpret_cast<jmethodID>(1001);
+  const jlocation location = 10031;
+
+  auto definition1 = BreakpointBuilder()
+      .set_id("ID_A")
+      .set_location("Class1.java", 31)
+      .build();
+
+  auto definition2 = BreakpointBuilder()
+      .set_id("ID_B")
+      .set_location("Class1.java", 31)
+      .build();
+
+  std::shared_ptr<MockBreakpoint> breakpoints[] = {
+    std::make_shared<NiceMock<MockBreakpoint>>("ID_A"),
+    std::make_shared<NiceMock<MockBreakpoint>>("ID_B")
+  };
+
+  EXPECT_CALL(*this, BreakpointFactory("ID_A"))
+      .WillOnce(Return(breakpoints[0]));
+
+  EXPECT_CALL(*this, BreakpointFactory("ID_B"))
+      .WillOnce(Return(breakpoints[1]));
+
+  InitializeBreakpointsManager();
+
+  SetActiveBreakpointsList({ definition1.get(), definition2.get() });
+
+  ExpectSetBreakpoint(method, location);
+  breakpoints_manager_->SetJvmtiBreakpoint(method, location, breakpoints[0]);
+  breakpoints_manager_->SetJvmtiBreakpoint(method, location, breakpoints[1]);
+
+  EXPECT_CALL(*breakpoints[0], OnJvmBreakpointHit(kThread, method, location))
+      .Times(1);
+
+  EXPECT_CALL(*breakpoints[1], OnJvmBreakpointHit(kThread, method, location))
+      .Times(1);
+
+  breakpoints_manager_->JvmtiOnBreakpoint(kThread, method, location);
+
+  ExpectClearBreakpoint(method, location);
+  breakpoints_manager_->ClearJvmtiBreakpoint(method, location, breakpoints[0]);
+  breakpoints_manager_->ClearJvmtiBreakpoint(method, location, breakpoints[1]);
+}
+
+
+TEST_F(JvmBreakpointsManagerTest, CompletedBreakpointsListCleanup) {
+  auto definition = BreakpointBuilder()
+      .set_id("ID_A")
+      .set_location("Class1.java", 31)
+      .build();
+
+  std::shared_ptr<MockBreakpoint> breakpoint =
+      std::make_shared<NiceMock<MockBreakpoint>>("ID_A");
+
+  EXPECT_CALL(*this, BreakpointFactory("ID_A"))
+      .WillOnce(Return(breakpoint));
+
+  InitializeBreakpointsManager();
+
+  SetActiveBreakpointsList({ definition.get() });
+
+  breakpoints_manager_->CompleteBreakpoint("ID_A");
+
+  // The completed breakpoint should be in "completed_breakpoints_" list,
+  // so setting the same breakpoint should have no effect.
+  SetActiveBreakpointsList({ definition.get() });
+
+  // Now send update without our breakpoint to clear "completed_breakpoints_".
+  SetActiveBreakpointsList({});
+
+  // At this point "completed_breakpoints_" should be empty, so setting the
+  // same breakpoint again will work.
+  EXPECT_CALL(*this, BreakpointFactory("ID_A"))
+      .WillOnce(Return(breakpoint));
+
+  SetActiveBreakpointsList({ definition.get() });
+}
+
+
+TEST_F(JvmBreakpointsManagerTest, AddCanarySuccess) {
+  auto bp = BreakpointBuilder()
+      .set_id("ID_A")
+      .set_location("Class1.java", 31)
+      .set_is_canary(true)
+      .build();
+
+  auto breakpoint = std::make_shared<StrictMock<MockBreakpoint>>("ID_A");
+  EXPECT_CALL(*this, BreakpointFactory("ID_A"))
+      .WillOnce(Return(breakpoint));
+
+  const std::string id = "ID_A";
+  EXPECT_CALL(*breakpoint, id())
+      .WillRepeatedly(ReturnRef(id));
+
+  EXPECT_CALL(*breakpoint, Initialize())
+      .WillOnce(Return());
+
+  EXPECT_CALL(*breakpoint, ResetToPending())
+      .WillOnce(Return());
+
+  EXPECT_CALL(bridge_, RegisterBreakpointCanary("ID_A"))
+      .WillOnce(Return(true));
+
+  CanaryControl canary_control(CallbacksMonitor::GetInstance(), &bridge_);
+  InitializeBreakpointsManager(&canary_control);
+  SetActiveBreakpointsList({ bp.get() });
+}
+
+
+TEST_F(JvmBreakpointsManagerTest, AddCanaryFailure) {
+  auto bp = BreakpointBuilder()
+      .set_id("ID_A")
+      .set_location("Class1.java", 31)
+      .set_is_canary(true)
+      .build();
+
+  auto breakpoint = std::make_shared<StrictMock<MockBreakpoint>>("ID_A");
+  EXPECT_CALL(*this, BreakpointFactory("ID_A"))
+      .WillOnce(Return(breakpoint));
+
+  const std::string id = "ID_A";
+  EXPECT_CALL(*breakpoint, id())
+      .WillRepeatedly(ReturnRef(id));
+
+  EXPECT_CALL(bridge_, RegisterBreakpointCanary("ID_A"))
+      .WillRepeatedly(Return(false));
+
+  CanaryControl canary_control(CallbacksMonitor::GetInstance(), &bridge_);
+  InitializeBreakpointsManager(&canary_control);
+  SetActiveBreakpointsList({ bp.get() });
+}
+
+}  // namespace cdbg
+}  // namespace devtools

--- a/tests/agent/jvm_class_indexer_test.cc
+++ b/tests/agent/jvm_class_indexer_test.cc
@@ -1,0 +1,237 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/agent/jvm_class_indexer.h"
+
+#include "gtest/gtest.h"
+#include "src/agent/jni_utils.h"
+#include "tests/agent/fake_jni.h"
+#include "tests/agent/mock_jni_env.h"
+#include "tests/agent/mock_jvmti_env.h"
+
+using testing::_;
+using testing::DoAll;
+using testing::Eq;
+using testing::IsNull;
+using testing::NiceMock;
+using testing::NotNull;
+using testing::Test;
+using testing::Return;
+using testing::ReturnNew;
+using testing::SaveArg;
+using testing::StrEq;
+using testing::WithArgs;
+using testing::Invoke;
+using testing::InvokeArgument;
+using testing::SetArgPointee;
+
+namespace devtools {
+namespace cdbg {
+
+class JvmClassIndexerTest : public ::testing::Test {
+ protected:
+  JvmClassIndexerTest()
+      : fake_jni_(&jvmti_, &jni_),
+        global_jvm_(&jvmti_, &jni_) {
+    fake_classes_ = {
+      fake_jni_.CreateNewClass({ "Class1.java", "Lcom/myprod/Class1;" }),
+      fake_jni_.CreateNewClass({ "Class2.java", "Lcom/myprod/Class2;" }),
+      fake_jni_.CreateNewClass({ "Class3.java", "Lcom/myprod/Class3;" }),
+      fake_jni_.CreateNewClass({ "Class4.java", "Lcom/myprod/Class4;" }),
+      fake_jni_.CreateNewClass({ "Ambiguous.java", "Lcom/myprod/Amb;" }),
+      fake_jni_.CreateNewClass({ "Ambiguous.java", "Lcom/myprod$Amb;" })
+    };
+  }
+
+  void TearDown() override {
+    for (jobject fake_class : fake_classes_) {
+      jni_.DeleteLocalRef(fake_class);
+    }
+  }
+
+ protected:
+  NiceMock<MockJvmtiEnv> jvmti_;
+  NiceMock<MockJNIEnv> jni_;
+  FakeJni fake_jni_;
+  GlobalJvmEnv global_jvm_;
+
+  // List of fake classes that test cases use.
+  std::vector<jclass> fake_classes_;
+};
+
+
+TEST_F(JvmClassIndexerTest, FindClassByName) {
+  JvmClassIndexer class_indexer;
+  class_indexer.Initialize();
+
+  EXPECT_TRUE(jni_.IsSameObject(
+      class_indexer.FindClassByName("com.myprod.Class1").get(),
+      fake_classes_[0]));
+
+  class_indexer.Cleanup();
+}
+
+
+TEST_F(JvmClassIndexerTest, FindClassByNameNegative) {
+  JvmClassIndexer class_indexer;
+  class_indexer.Initialize();
+
+  EXPECT_EQ(nullptr, class_indexer.FindClassByName("com.myprod.Class1A"));
+
+  class_indexer.Cleanup();
+}
+
+
+TEST_F(JvmClassIndexerTest, FindClassBySignature) {
+  JvmClassIndexer class_indexer;
+  class_indexer.Initialize();
+
+  EXPECT_TRUE(jni_.IsSameObject(
+      class_indexer.FindClassBySignature("Lcom/myprod/Class1;").get(),
+      fake_classes_[0]));
+
+  class_indexer.Cleanup();
+}
+
+
+TEST_F(JvmClassIndexerTest, FindReclaimedClassBySignature) {
+  JvmClassIndexer class_indexer;
+  class_indexer.Initialize();
+
+  JniLocalRef cls(fake_jni_.CreateNewClass({ "My.java", "LMy;" }));
+  jobject weak_ref = jni_.NewWeakGlobalRef(cls.get());
+
+  EXPECT_CALL(jni_, NewWeakGlobalRef(NotNull()))
+      .WillOnce(Return(weak_ref));
+
+  class_indexer.JvmtiOnClassPrepare(static_cast<jclass>(cls.get()));
+
+  EXPECT_TRUE(jni_.IsSameObject(
+      class_indexer.FindClassBySignature("LMy;").get(),
+      cls.get()));
+
+  fake_jni_.InvalidateObject(weak_ref);
+
+  EXPECT_EQ(nullptr, class_indexer.FindClassBySignature("LMy;"));
+
+  class_indexer.Cleanup();
+}
+
+
+TEST_F(JvmClassIndexerTest, AmbiguousClassBySignature) {
+  JvmClassIndexer class_indexer;
+  class_indexer.Initialize();
+
+  EXPECT_TRUE(jni_.IsSameObject(
+      class_indexer.FindClassBySignature("Lcom/myprod$Amb;").get(),
+      fake_classes_[5]));
+
+  EXPECT_TRUE(jni_.IsSameObject(
+      class_indexer.FindClassBySignature("Lcom/myprod/Amb;").get(),
+      fake_classes_[4]));
+
+  class_indexer.Cleanup();
+}
+
+
+TEST_F(JvmClassIndexerTest, FindClassBySignatureNegative) {
+  JvmClassIndexer class_indexer;
+  class_indexer.Initialize();
+
+  EXPECT_EQ(nullptr,
+            class_indexer.FindClassBySignature("Lcom/myprod/Class1A;"));
+
+  class_indexer.Cleanup();
+}
+
+
+TEST_F(JvmClassIndexerTest, ClassPrepare) {
+  JvmClassIndexer class_indexer;
+
+  EXPECT_EQ(nullptr, class_indexer.FindClassByName("com.myprod.Class3"));
+
+  class_indexer.JvmtiOnClassPrepare(fake_classes_[2]);
+
+  EXPECT_TRUE(jni_.IsSameObject(
+      class_indexer.FindClassByName("com.myprod.Class3").get(),
+      fake_classes_[2]));
+
+  class_indexer.Cleanup();
+}
+
+
+TEST_F(JvmClassIndexerTest, OnClassPrepareEvent) {
+  JvmClassIndexer class_indexer;
+
+  int callback_counter = 0;
+  auto cookie = class_indexer.SubscribeOnClassPreparedEvents(
+      [this, &callback_counter](const std::string& type_name,
+                                const std::string& class_signature) {
+        ++callback_counter;
+        EXPECT_EQ(1, callback_counter);
+
+        EXPECT_EQ("com.myprod.Class3", type_name);
+        EXPECT_EQ("Lcom/myprod/Class3;", class_signature);
+      });
+
+  class_indexer.JvmtiOnClassPrepare(fake_classes_[2]);
+
+  class_indexer.UnsubscribeOnClassPreparedEvents(std::move(cookie));
+
+  class_indexer.Cleanup();
+}
+
+
+TEST_F(JvmClassIndexerTest, ClassUnloaded) {
+  JvmClassIndexer class_indexer;
+  class_indexer.Initialize();
+
+  fake_jni_.InvalidateObject(fake_classes_[0]);
+
+  EXPECT_EQ(nullptr,
+            class_indexer.FindClassBySignature("Lcom/myprod/Class1;"));
+
+  class_indexer.Cleanup();
+}
+
+
+TEST_F(JvmClassIndexerTest, ClassReferenceLoadedClass) {
+  JvmClassIndexer class_indexer;
+  class_indexer.Initialize();
+
+  std::shared_ptr<ClassIndexer::Type> type =
+      class_indexer.GetReference("Lcom/prod/MyClass1;");
+  EXPECT_EQ(JType::Object, type->GetType());
+  EXPECT_EQ("Lcom/prod/MyClass1;", type->GetSignature());
+  EXPECT_TRUE(jni_.IsSameObject(
+      fake_jni_.GetStockClass(FakeJni::StockClass::MyClass1),
+      type->FindClass()));
+}
+
+
+TEST_F(JvmClassIndexerTest, ClassReferenceUnknownClass) {
+  JvmClassIndexer class_indexer;
+  class_indexer.Initialize();
+
+  std::shared_ptr<ClassIndexer::Type> type =
+      class_indexer.GetReference("Lcom/prod/UnknownClass;");
+  EXPECT_EQ(JType::Object, type->GetType());
+  EXPECT_EQ("Lcom/prod/UnknownClass;", type->GetSignature());
+  EXPECT_EQ(nullptr, type->FindClass());
+}
+
+}  // namespace cdbg
+}  // namespace devtools

--- a/tests/agent/jvm_class_metadata_reader_test.cc
+++ b/tests/agent/jvm_class_metadata_reader_test.cc
@@ -1,0 +1,898 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/agent/jvm_class_metadata_reader.h"
+
+#include <cstdint>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "mock_object.h"
+#include "src/agent/glob_data_visibility_policy.h"
+#include "src/agent/instance_field_reader.h"
+#include "src/agent/static_field_reader.h"
+#include "src/agent/structured_data_visibility_policy.h"
+#include "tests/agent/mock_jni_env.h"
+#include "tests/agent/mock_jvmti_env.h"
+
+using testing::_;
+using testing::AtMost;
+using testing::DoAll;
+using testing::Eq;
+using testing::IsNull;
+using testing::Invoke;
+using testing::NiceMock;
+using testing::NotNull;
+using testing::Test;
+using testing::Return;
+using testing::SetArgPointee;
+
+namespace devtools {
+namespace cdbg {
+
+class ProhibitiveFieldsVisibility : public DataVisibilityPolicy {
+ public:
+  std::unique_ptr<Class> GetClassVisibility(jclass cls) override {
+    return std::unique_ptr<Class>(new ClassImpl);
+  }
+
+  bool HasSetupError(std::string* error) const override { return false; }
+
+ private:
+  class ClassImpl : public Class {
+    bool IsFieldVisible(const std::string& name,
+                        int32_t field_modifiers) override {
+      return false;
+    }
+
+    bool IsFieldDataVisible(const std::string& name, int32_t field_modifiers,
+                            std::string* reason) override {
+      return false;
+    }
+
+    bool IsMethodVisible(const std::string& method_name,
+                         const std::string& method_signature,
+                         int32_t method_modifiers) override {
+      return true;
+    }
+
+    bool IsVariableVisible(const std::string& method_name,
+                           const std::string& method_signature,
+                           const std::string& variable_name) override {
+      return true;
+    }
+
+    bool IsVariableDataVisible(const std::string& method_name,
+                               const std::string& method_signature,
+                               const std::string& variable_name,
+                               std::string* reason) override {
+      return true;
+    }
+  };
+};
+
+
+class ProhibitiveMethodsVisibility : public DataVisibilityPolicy {
+ public:
+  std::unique_ptr<Class> GetClassVisibility(jclass cls) override {
+    return std::unique_ptr<Class>(new ClassImpl);
+  }
+
+  bool HasSetupError(std::string* error) const override { return false; }
+
+ private:
+  class ClassImpl : public Class {
+    bool IsFieldVisible(const std::string& name,
+                        int32_t field_modifiers) override {
+      return true;
+    }
+
+    bool IsFieldDataVisible(const std::string& name, int32_t field_modifiers,
+                            std::string* reason) override {
+      return true;
+    }
+
+    bool IsMethodVisible(const std::string& method_name,
+                         const std::string& method_signature,
+                         int32_t method_modifiers) override {
+      return false;
+    }
+
+    bool IsVariableVisible(const std::string& method_name,
+                           const std::string& method_signature,
+                           const std::string& variable_name) override {
+      return true;
+    }
+
+    bool IsVariableDataVisible(const std::string& method_name,
+                               const std::string& method_signature,
+                               const std::string& variable_name,
+                               std::string* reason) override {
+      return true;
+    }
+  };
+};
+
+
+//
+// Simulate this hierarchy:
+//
+// class SuperClass (implicitly extends Object)
+// interface SuperInterface (implicitly extends Object)
+// interface CustomInterface extends SuperInterface (implicitly extends Object)
+// class CustomClass implements CustomInterface extends SuperClass
+//
+
+static const jclass kCustomClass = reinterpret_cast<jclass>(0x1234456556L);
+static const jclass kCustomInterface = reinterpret_cast<jclass>(0x656234L);
+static const jclass kSuperInterface = reinterpret_cast<jclass>(0x4727834L);
+static const jclass kSuperClass = reinterpret_cast<jclass>(0x34765432L);
+static const jclass kObjectClass = reinterpret_cast<jclass>(0x9078243L);
+
+static constexpr char kCustomClassSignature[] = "Lcom/prod/MyFavoriteClass;";
+static constexpr char kCustomInterfaceSignature[] = "LCustomInterface;";
+static constexpr char kSuperInterfaceSignature[] = "LSuperInterface;";
+static constexpr char kSuperClassSignature[] = "Lorg/ngo/TheirSuperClass;";
+static constexpr char kObjectClassSignature[] = "Ljava/lang/Object;";
+
+static const struct ClassFields {
+  jclass cls;
+  std::vector<jfieldID> fields;
+} classes_fields[] = {
+  {
+    kCustomClass,
+    {
+      reinterpret_cast<jfieldID>(100),
+      reinterpret_cast<jfieldID>(101),
+      reinterpret_cast<jfieldID>(201),
+      reinterpret_cast<jfieldID>(102),
+      reinterpret_cast<jfieldID>(103),
+      reinterpret_cast<jfieldID>(104),
+      reinterpret_cast<jfieldID>(105),
+      reinterpret_cast<jfieldID>(106),
+      reinterpret_cast<jfieldID>(206),
+      reinterpret_cast<jfieldID>(107),
+      reinterpret_cast<jfieldID>(108),
+      reinterpret_cast<jfieldID>(109),
+      reinterpret_cast<jfieldID>(110)
+    },
+  },
+  {
+    kCustomInterface,
+    {}
+  },
+  {
+    kSuperInterface,
+    {}
+  },
+  {
+    kSuperClass,
+    {
+      reinterpret_cast<jfieldID>(111),
+      reinterpret_cast<jfieldID>(212)
+    }
+  },
+  {
+    kObjectClass,
+    {}
+  }
+};
+
+static const struct ClassMethods {
+  jclass cls;
+  std::vector<jmethodID> methods;
+} classes_methods[] = {
+  {
+    kCustomClass,
+    {
+      reinterpret_cast<jmethodID>(0x41),
+      reinterpret_cast<jmethodID>(0x42),
+      reinterpret_cast<jmethodID>(0x43),
+      reinterpret_cast<jmethodID>(0x44),
+      reinterpret_cast<jmethodID>(0x45),
+      reinterpret_cast<jmethodID>(0x46)
+    },
+  },
+  {
+    kCustomInterface,
+    {
+      reinterpret_cast<jmethodID>(0x60)
+    }
+  },
+  {
+    kSuperInterface,
+    {
+      reinterpret_cast<jmethodID>(0x70)
+    }
+  },
+  {
+    kSuperClass,
+    {
+      reinterpret_cast<jmethodID>(0x47),
+      reinterpret_cast<jmethodID>(0x48),
+      reinterpret_cast<jmethodID>(0x49),
+      reinterpret_cast<jmethodID>(0x4A)
+    }
+  },
+  {
+    kObjectClass,
+    {
+        reinterpret_cast<jmethodID>(0x50),
+    }
+  }
+};
+
+static const struct SuperclassInfo {
+  jclass cls;
+  jclass super;
+  std::vector<jclass> interfaces;
+} superclass_infos[] = {
+  {
+    kCustomClass,           // cls
+    kSuperClass,            // super
+    {                       // interfaces
+      kCustomInterface
+    }
+  },
+  {
+    kCustomInterface,       // cls
+    nullptr,                // super
+    {                       // interfaces
+      kSuperInterface
+    }
+  },
+  {
+    kSuperInterface,        // cls
+    nullptr                 // super
+  },
+  {
+    kSuperClass,            // cls
+    kObjectClass            // super
+  },
+  {
+    kObjectClass,           // cls
+    nullptr                 // super
+  }
+};
+
+static const struct FieldInfo {
+  jclass cls;
+  jfieldID field_id;
+  const char* name;
+  const char* signature;
+  jint modifiers;
+} field_infos[] = {
+  {
+    kCustomClass,                     // cls
+    reinterpret_cast<jfieldID>(100),  // field_id
+    "myint",                          // name
+    "I",                              // signature
+    0                                 // modifiers
+  },
+  {
+    kCustomClass,                     // cls
+    reinterpret_cast<jfieldID>(101),  // field_id
+    "mybool",                         // name
+    "Z",                              // signature
+    0                                 // modifiers
+  },
+  {
+    kCustomClass,                     // cls
+    reinterpret_cast<jfieldID>(201),  // field_id
+    "myStaticBool",                   // name
+    "Z",                              // signature
+    JVM_ACC_STATIC                    // modifiers
+  },
+  {
+    kCustomClass,                     // cls
+    reinterpret_cast<jfieldID>(102),  // field_id
+    "mybyte",                         // name
+    "B",                              // signature
+    0                                 // modifiers
+  },
+  {
+    kCustomClass,                       // cls
+    reinterpret_cast<jfieldID>(103),    // field_id
+    "mychar",                           // name
+    "C",                                // signature
+    0                                   // modifiers
+  },
+  {
+    kCustomClass,                       // cls
+    reinterpret_cast<jfieldID>(104),    // field_id
+    "myshort",                          // name
+    "S",                                // signature
+    0                                   // modifiers
+  },
+  {
+    kCustomClass,                       // cls
+    reinterpret_cast<jfieldID>(105),    // field_id
+    "mylong",                           // name
+    "J",                                // signature
+    0                                   // modifiers
+  },
+  {
+    kCustomClass,                       // cls
+    reinterpret_cast<jfieldID>(106),    // field_id
+    "myfloat",                          // name
+    "F",                                // signature
+    0                                   // modifiers
+  },
+  {
+    kCustomClass,                       // cls
+    reinterpret_cast<jfieldID>(206),    // field_id
+    "myStaticFloat",                    // name
+    "F",                                // signature
+    JVM_ACC_STATIC                      // modifiers
+  },
+  {
+    kCustomClass,                       // cls
+    reinterpret_cast<jfieldID>(107),    // field_id
+    "mydouble",                         // name
+    "D",                                // signature
+    0                                   // modifiers
+  },
+  {
+    kCustomClass,                       // cls
+    reinterpret_cast<jfieldID>(108),    // field_id
+    "mystring",                         // name
+    "Ljava/lang/String",                // signature
+    0                                   // modifiers
+  },
+  {
+    kCustomClass,                       // cls
+    reinterpret_cast<jfieldID>(109),    // field_id
+    "myintarray",                       // name
+    "[I",                               // signature
+    0                                   // modifiers
+  },
+  {
+    kCustomClass,                       // cls
+    reinterpret_cast<jfieldID>(110),    // field_id
+    "myStaticDouble",                   // name
+    "D",                                // signature
+    JVM_ACC_STATIC                      // modifiers
+  },
+  {
+    kSuperClass,                        // cls
+    reinterpret_cast<jfieldID>(111),    // field_id
+    "superdouble",                      // name
+    "D",                                // signature
+    0                                   // modifiers
+  },
+  {
+    kSuperClass,                        // cls
+    reinterpret_cast<jfieldID>(212),    // field_id
+    "mySuperStaticInt",                 // name
+    "I",                                // signature
+    JVM_ACC_STATIC                      // modifiers
+  }
+};
+
+
+static const struct MethodInfo {
+  jclass cls;
+  jmethodID method_id;
+  const char* name;
+  const char* signature;
+  jint modifiers;
+} method_infos[] = {
+  {
+    kCustomClass,                       // cls
+    reinterpret_cast<jmethodID>(0x41),  // method_id
+    "firstMethod",                      // name
+    "(Z)[I",                            // signature
+    0                                   // modifiers
+  },
+  {
+    kCustomClass,                       // cls
+    reinterpret_cast<jmethodID>(0x42),  // method_id
+    "firstMethod",                      // name
+    "(I)[I",                            // signature
+    0                                   // modifiers
+  },
+  {
+    kCustomClass,                       // cls
+    reinterpret_cast<jmethodID>(0x43),  // method_id
+    "secondMethod",                     // name
+    "()V",                              // signature
+    0                                   // modifiers
+  },
+  {
+    kCustomClass,                       // cls
+    reinterpret_cast<jmethodID>(0x44),  // method_id
+    "staticMethod",                     // name
+    "()Ljava/lang/String;",             // signature
+    JVM_ACC_STATIC                      // modifiers
+  },
+  {
+    kCustomClass,                       // cls
+    reinterpret_cast<jmethodID>(0x45),  // method_id
+    "instanceOverload",                 // name
+    "(ZIZI)LSomeBaseClass;",            // signature
+    0                                   // modifiers
+  },
+  {
+    kCustomClass,                       // cls
+    reinterpret_cast<jmethodID>(0x46),  // method_id
+    "staticOverload",                   // name
+    "(ZIZI)LSomeBaseClass;",            // signature
+    JVM_ACC_STATIC                      // modifiers
+  },
+  {
+    kCustomInterface,                   // cls
+    reinterpret_cast<jmethodID>(0x60),  // method_id
+    "customInterfaceMethod",            // name
+    "()V;",                             // signature
+    0,                                  // modifiers
+  },
+  {
+    kSuperInterface,                    // cls
+    reinterpret_cast<jmethodID>(0x70),  // method_id
+    "superInterfaceMethod",             // name
+    "()V;",                             // signature
+    0,                                  // modifiers
+  },
+  {
+    kSuperClass,                        // cls
+    reinterpret_cast<jmethodID>(0x47),  // method_id
+    "superInstanceMethod",              // name
+    "(Ljava/lang/String;)Z",            // signature
+    0                                   // modifiers
+  },
+  {
+    kSuperClass,                        // cls
+    reinterpret_cast<jmethodID>(0x48),  // method_id
+    "superStaticMethod",                // name
+    "(Ljava/lang/String;)Z",            // signature
+    JVM_ACC_STATIC                      // modifiers
+  },
+  {
+    kSuperClass,                        // cls
+    reinterpret_cast<jmethodID>(0x49),  // method_id
+    "instanceOverload",                 // name
+    "(ZIZI)LSomeSuperClass;",           // signature
+    0                                   // modifiers
+  },
+  {
+    kSuperClass,                        // cls
+    reinterpret_cast<jmethodID>(0x4A),  // method_id
+    "staticOverload",                   // name
+    "(ZIZI)LSomeSuperClass;",           // signature
+    JVM_ACC_STATIC                      // modifiers
+  },
+  {
+    kObjectClass,                       // cls
+    reinterpret_cast<jmethodID>(0x50),  // method_id
+    "toString",                         // name
+    "()Ljava/lang/String;",             // signature
+    0,                                  // modifiers
+  }
+};
+
+
+// Gets pointer to the buffer of std::vector removing const qualifier.
+template <typename T>
+T* GetVectorData(const std::vector<T>& v) {
+  if (v.empty()) {
+    return nullptr;
+  }
+
+  return const_cast<T*>(v.data());
+}
+
+
+class JvmClassMetadataReaderTest : public ::testing::Test {
+ protected:
+  JvmClassMetadataReaderTest() : global_jvm_(&jvmti_, &jni_) {
+  }
+
+  void SetUp() override {
+    jniproxy::InjectObject(&object_);
+
+    EXPECT_CALL(object_, GetClass())
+        .WillRepeatedly(Return(kObjectClass));
+
+    EXPECT_CALL(jni_, GetObjectRefType(_))
+        .WillRepeatedly(Return(JNILocalRefType));
+
+    EXPECT_CALL(jni_, NewLocalRef(_))
+        .WillRepeatedly(Invoke([] (jobject obj) {
+          return obj;
+        }));
+
+    EXPECT_CALL(jni_, NewGlobalRef(_))
+        .WillRepeatedly(Invoke([] (jobject obj) { return obj; }));
+
+    EXPECT_CALL(jni_, NewWeakGlobalRef(_))
+        .WillRepeatedly(Invoke([] (jobject obj) {
+          return obj;
+        }));
+
+    EXPECT_CALL(jni_, DeleteWeakGlobalRef(_))
+        .WillRepeatedly(Return());
+
+    EXPECT_CALL(jni_, DeleteLocalRef(_))
+        .WillRepeatedly(Return());
+
+    EXPECT_CALL(jni_, DeleteGlobalRef(_))
+        .WillRepeatedly(Return());
+
+    EXPECT_CALL(jni_, IsSameObject(_, _))
+        .WillRepeatedly(Invoke([] (jobject obj1, jobject obj2) {
+          return obj1 == obj2;
+        }));
+
+    EXPECT_CALL(jvmti_, Deallocate(NotNull()))
+        .WillRepeatedly(Return(JVMTI_ERROR_NONE));
+
+    EXPECT_CALL(jvmti_, GetObjectHashCode(_, NotNull()))
+        .WillRepeatedly(DoAll(SetArgPointee<1>(0), Return(JVMTI_ERROR_NONE)));
+
+    EXPECT_CALL(jvmti_, GetClassSignature(kCustomClass, NotNull(), nullptr))
+        .WillRepeatedly(DoAll(
+            SetArgPointee<1>(const_cast<char*>(kCustomClassSignature)),
+            Return(JVMTI_ERROR_NONE)));
+
+    EXPECT_CALL(jvmti_, GetClassSignature(kCustomInterface, NotNull(), nullptr))
+        .WillRepeatedly(DoAll(
+            SetArgPointee<1>(const_cast<char*>(kCustomInterfaceSignature)),
+            Return(JVMTI_ERROR_NONE)));
+
+    EXPECT_CALL(jvmti_, GetClassSignature(kSuperInterface, NotNull(), nullptr))
+        .WillRepeatedly(DoAll(
+            SetArgPointee<1>(const_cast<char*>(kSuperInterfaceSignature)),
+            Return(JVMTI_ERROR_NONE)));
+
+    EXPECT_CALL(jvmti_, GetClassSignature(kSuperClass, NotNull(), nullptr))
+        .WillRepeatedly(DoAll(
+            SetArgPointee<1>(const_cast<char*>(kSuperClassSignature)),
+            Return(JVMTI_ERROR_NONE)));
+
+    EXPECT_CALL(jvmti_, GetClassSignature(kObjectClass, NotNull(), nullptr))
+        .WillRepeatedly(DoAll(
+            SetArgPointee<1>(const_cast<char*>(kObjectClassSignature)),
+            Return(JVMTI_ERROR_NONE)));
+
+    for (const auto& class_fields : classes_fields) {
+      EXPECT_CALL(
+          jvmti_,
+          GetClassFields(class_fields.cls, NotNull(), NotNull()))
+          .Times(AtMost(1))  // AtMost(1) verifies class metadata cache.
+          .WillRepeatedly(DoAll(
+              SetArgPointee<1>(class_fields.fields.size()),
+              SetArgPointee<2>(GetVectorData(class_fields.fields)),
+              Return(JVMTI_ERROR_NONE)));
+    }
+
+    for (const auto& class_methods : classes_methods) {
+      EXPECT_CALL(
+          jvmti_,
+          GetClassMethods(class_methods.cls, NotNull(), NotNull()))
+          .Times(AtMost(1))  // AtMost(1) verifies class metadata cache.
+          .WillRepeatedly(DoAll(
+              SetArgPointee<1>(class_methods.methods.size()),
+              SetArgPointee<2>(GetVectorData(class_methods.methods)),
+              Return(JVMTI_ERROR_NONE)));
+    }
+
+    for (const auto& field_info : field_infos) {
+      EXPECT_CALL(
+          jvmti_,
+          GetFieldModifiers(field_info.cls, field_info.field_id, NotNull()))
+          .WillRepeatedly(DoAll(
+              SetArgPointee<2>(field_info.modifiers),
+              Return(JVMTI_ERROR_NONE)));
+
+      EXPECT_CALL(
+          jvmti_,
+          GetFieldName(
+              field_info.cls,
+              field_info.field_id,
+              NotNull(),
+              NotNull(),
+              nullptr))
+          .WillRepeatedly(DoAll(
+              SetArgPointee<2>(const_cast<char*>(field_info.name)),
+              SetArgPointee<3>(const_cast<char*>(field_info.signature)),
+              Return(JVMTI_ERROR_NONE)));
+    }
+
+    for (const auto& method_info : method_infos) {
+      EXPECT_CALL(
+          jvmti_,
+          GetMethodModifiers(method_info.method_id, NotNull()))
+          .WillRepeatedly(DoAll(
+              SetArgPointee<1>(method_info.modifiers),
+              Return(JVMTI_ERROR_NONE)));
+
+      EXPECT_CALL(
+          jvmti_,
+          GetMethodName(method_info.method_id, NotNull(), NotNull(), nullptr))
+          .WillRepeatedly(DoAll(
+              SetArgPointee<1>(const_cast<char*>(method_info.name)),
+              SetArgPointee<2>(const_cast<char*>(method_info.signature)),
+              Return(JVMTI_ERROR_NONE)));
+    }
+
+    for (const auto& superclass_info : superclass_infos) {
+      EXPECT_CALL(jni_, GetSuperclass(superclass_info.cls))
+          .WillRepeatedly(Return(superclass_info.super));
+
+      EXPECT_CALL(jvmti_, GetImplementedInterfaces(superclass_info.cls, _, _))
+          .WillRepeatedly(DoAll(
+              SetArgPointee<1>(superclass_info.interfaces.size()),
+              SetArgPointee<2>(GetVectorData(superclass_info.interfaces)),
+              Return(JVMTI_ERROR_NONE)));
+    }
+  }
+
+  void TearDown() override {
+    jniproxy::InjectObject(nullptr);
+  }
+
+ protected:
+  NiceMock<MockJvmtiEnv> jvmti_;
+  MockJNIEnv jni_;
+  GlobalJvmEnv global_jvm_;
+  NiceMock<jniproxy::MockObject> object_;
+};
+
+
+TEST_F(JvmClassMetadataReaderTest, GetClassMetadata) {
+  StructuredDataVisibilityPolicy data_visibility_policy;
+  JvmClassMetadataReader metadata_reader(&data_visibility_policy);
+  const auto& metadata = metadata_reader.GetClassMetadata(kCustomClass);
+
+  EXPECT_EQ(JType::Object, metadata.signature.type);
+  EXPECT_EQ(kCustomClassSignature, metadata.signature.object_signature);
+
+  std::vector<std::string> instance_field_names;
+  for (const auto& instance_field : metadata.instance_fields) {
+    instance_field_names.push_back(instance_field->GetName());
+    jobject source_object = nullptr;
+    JVariant result;
+    FormatMessageModel message;
+    EXPECT_TRUE(instance_field->ReadValue(source_object, &result, &message));
+  }
+
+  std::vector<std::string> static_field_names;
+  for (const auto& static_field : metadata.static_fields) {
+    static_field_names.push_back(static_field->GetName());
+    JVariant result;
+    FormatMessageModel message;
+    EXPECT_TRUE(static_field->ReadValue(&result, &message));
+  }
+
+  EXPECT_EQ(std::vector<std::string>(
+                {"superdouble",  // Fields from base class go first.
+                 "myint", "mybool", "mybyte", "mychar", "myshort", "mylong",
+                 "myfloat", "mydouble", "mystring", "myintarray"}),
+            instance_field_names);
+
+  EXPECT_EQ(std::vector<std::string>(
+                {"mySuperStaticInt",  // Fields from base class go first.
+                 "myStaticBool", "myStaticFloat", "myStaticDouble"}),
+            static_field_names);
+
+  // Specifically verify overriding rules due to virtual functions.
+  std::vector<std::string> expected_methods(
+      {"9:Lcom/prod/MyFavoriteClass;:firstMethod:(Z)[I:0",
+       "9:Lcom/prod/MyFavoriteClass;:firstMethod:(I)[I:0",
+       "9:Lcom/prod/MyFavoriteClass;:secondMethod:()V:0",
+       "9:Lcom/prod/MyFavoriteClass;:staticMethod:()Ljava/lang/String;:8",
+       "9:Lcom/prod/MyFavoriteClass;:instanceOverload:(ZIZI)LSomeBaseClass;:0",
+       "9:Lcom/prod/MyFavoriteClass;:staticOverload:(ZIZI)LSomeBaseClass;:8",
+       "9:LCustomInterface;:customInterfaceMethod:()V;:0",
+       "9:LSuperInterface;:superInterfaceMethod:()V;:0",
+       "9:Lorg/ngo/TheirSuperClass;:superInstanceMethod:(Ljava/lang/"
+       "String;)Z:0",
+       "9:Lorg/ngo/TheirSuperClass;:superStaticMethod:(Ljava/lang/String;)Z:8",
+       "9:Lorg/ngo/TheirSuperClass;:staticOverload:(ZIZI)LSomeSuperClass;:8",
+       "9:Ljava/lang/Object;:toString:()Ljava/lang/String;:0"});
+
+  std::vector<std::string> actual_methods;
+  for (const auto& method_metadata : metadata.methods) {
+    actual_methods.push_back(
+        std::to_string(static_cast<int>(method_metadata.class_signature.type)) +
+        ":" +
+        method_metadata.class_signature.object_signature +
+        ":" +
+        method_metadata.name +
+        ":" +
+        method_metadata.signature +
+        ":" +
+        std::to_string(method_metadata.modifiers));
+  }
+
+  EXPECT_EQ(expected_methods, actual_methods);
+  EXPECT_FALSE(metadata.instance_fields_omitted);
+}
+
+
+TEST_F(JvmClassMetadataReaderTest, ImplicitObjectSuperclass) {
+  StructuredDataVisibilityPolicy data_visibility_policy;
+  JvmClassMetadataReader metadata_reader(&data_visibility_policy);
+  const auto& metadata = metadata_reader.GetClassMetadata(kCustomInterface);
+
+  for (const auto& method : metadata.methods) {
+    if ((method.class_signature.object_signature == kObjectClassSignature) &&
+        (method.name == "toString")) {
+      return;  // Test passed.
+    }
+  }
+
+  ADD_FAILURE() << "Object.toString not found in class metadata";
+}
+
+
+TEST_F(JvmClassMetadataReaderTest, StaticFieldClassReference) {
+  StructuredDataVisibilityPolicy data_visibility_policy;
+  JvmClassMetadataReader metadata_reader(&data_visibility_policy);
+  const auto& metadata = metadata_reader.GetClassMetadata(kCustomClass);
+
+  EXPECT_CALL(
+      jni_,
+      GetStaticDoubleField(kCustomClass, reinterpret_cast<jfieldID>(110)))
+      .WillOnce(Return(3.14));
+
+  EXPECT_CALL(
+      jni_,
+      GetStaticIntField(kSuperClass, reinterpret_cast<jfieldID>(212)))
+      .WillOnce(Return(721));
+
+  const StaticFieldReader* my_static_double_reader = nullptr;
+  const StaticFieldReader* my_super_static_int_reader = nullptr;
+
+  for (const auto& static_field : metadata.static_fields) {
+    if (static_field->GetName() == "myStaticDouble") {
+      my_static_double_reader = static_field.get();
+    }
+
+    if (static_field->GetName() == "mySuperStaticInt") {
+      my_super_static_int_reader = static_field.get();
+    }
+  }
+
+  ASSERT_TRUE(my_static_double_reader != nullptr);
+  ASSERT_TRUE(my_super_static_int_reader != nullptr);
+
+  JVariant my_static_double;
+  FormatMessageModel error;
+  EXPECT_TRUE(my_static_double_reader->ReadValue(&my_static_double, &error));
+
+  double my_static_double_value = 0;
+  EXPECT_TRUE(my_static_double.get<jdouble>(&my_static_double_value));
+  EXPECT_EQ(3.14, my_static_double_value);
+
+  JVariant my_super_static_int;
+  EXPECT_TRUE(
+      my_super_static_int_reader->ReadValue(&my_super_static_int, &error));
+
+  int my_super_static_int_value = 0;
+  EXPECT_TRUE(my_super_static_int.get<jint>(&my_super_static_int_value));
+  EXPECT_EQ(721, my_super_static_int_value);
+}
+
+
+TEST_F(JvmClassMetadataReaderTest, Cache) {
+  // SetUp configures "GetClassFields" to expect only a single call for each
+  // class. If cache doesn't work, "GetClassFields" will be called twice and
+  // this test will fail.
+
+  StructuredDataVisibilityPolicy data_visibility_policy;
+  JvmClassMetadataReader metadata_reader(&data_visibility_policy);
+  metadata_reader.GetClassMetadata(kCustomClass);
+  metadata_reader.GetClassMetadata(kCustomClass);
+}
+
+
+TEST_F(JvmClassMetadataReaderTest, StructuredFieldVisibilityPolicy) {
+  StructuredDataVisibilityPolicy::Config config;
+  auto& fields = config.packages["com/prod"].classes["MyFavoriteClass"].fields;
+  fields.resize(2);
+  fields[0].name = "myint";
+  fields[0].invisible = true;
+  fields[1].name = "myStaticBool";
+  fields[1].invisible = true;
+
+  StructuredDataVisibilityPolicy data_visibility_policy;
+  data_visibility_policy.SetConfig(config);
+  JvmClassMetadataReader metadata_reader(&data_visibility_policy);
+  const auto& metadata = metadata_reader.GetClassMetadata(kCustomClass);
+
+  std::vector<std::string> instance_field_names;
+  for (const auto& instance_field : metadata.instance_fields) {
+    instance_field_names.push_back(instance_field->GetName());
+  }
+
+  std::vector<std::string> static_field_names;
+  for (const auto& static_field : metadata.static_fields) {
+    static_field_names.push_back(static_field->GetName());
+  }
+
+  // Verify that only "myint" is filtered out.
+  EXPECT_EQ(std::vector<std::string>(
+                {"superdouble",  // Fields from base class go first.
+                 "mybool", "mybyte", "mychar", "myshort", "mylong", "myfloat",
+                 "mydouble", "mystring", "myintarray"}),
+            instance_field_names);
+
+  // Verify that only "myStaticBool" is filtered out.
+  EXPECT_EQ(std::vector<std::string>(
+                {"mySuperStaticInt",  // Fields from base class go first.
+                 "myStaticFloat", "myStaticDouble"}),
+            static_field_names);
+
+  EXPECT_TRUE(metadata.instance_fields_omitted);
+}
+
+
+TEST_F(JvmClassMetadataReaderTest, GlobFieldVisibilityPolicy) {
+  GlobDataVisibilityPolicy::Config config;
+  config.blocklists.Add("*");
+  config.blocklists.Prepare();
+  GlobDataVisibilityPolicy data_visibility_policy;
+  data_visibility_policy.SetConfig(config);
+
+  JvmClassMetadataReader metadata_reader(&data_visibility_policy);
+  const auto& metadata = metadata_reader.GetClassMetadata(kCustomClass);
+
+  EXPECT_EQ(11, metadata.instance_fields.size());
+
+  for (const auto& instance_field : metadata.instance_fields) {
+    jobject source_object = nullptr;
+    JVariant result;
+    FormatMessageModel message;
+    // Object should NOT be readable
+    EXPECT_FALSE(instance_field->ReadValue(source_object, &result, &message));
+    EXPECT_NE("", message.format);
+  }
+
+  EXPECT_EQ(4, metadata.static_fields.size());
+
+  for (const auto& static_field : metadata.static_fields) {
+    JVariant result;
+    FormatMessageModel message;
+    // Object should NOT be readable
+    EXPECT_FALSE(static_field->ReadValue(&result, &message));
+    EXPECT_NE("", message.format);
+  }
+}
+
+
+TEST_F(JvmClassMetadataReaderTest, ProhibitiveFieldVisibilityPolicy) {
+  ProhibitiveFieldsVisibility data_visibility_policy;
+  JvmClassMetadataReader metadata_reader(&data_visibility_policy);
+  const auto& metadata = metadata_reader.GetClassMetadata(kCustomClass);
+
+  EXPECT_EQ(0, metadata.instance_fields.size());
+  EXPECT_EQ(0, metadata.static_fields.size());
+  EXPECT_TRUE(metadata.instance_fields_omitted);
+}
+
+
+TEST_F(JvmClassMetadataReaderTest, ProhibitiveMethodVisibilityPolicy) {
+  ProhibitiveMethodsVisibility data_visibility_policy;
+  JvmClassMetadataReader metadata_reader(&data_visibility_policy);
+  const auto& metadata = metadata_reader.GetClassMetadata(kCustomClass);
+
+  EXPECT_EQ(0, metadata.methods.size());
+  EXPECT_FALSE(metadata.instance_fields_omitted);
+}
+
+}  // namespace cdbg
+}  // namespace devtools

--- a/tests/agent/jvm_instance_field_reader_test.cc
+++ b/tests/agent/jvm_instance_field_reader_test.cc
@@ -1,0 +1,214 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/agent/jvm_instance_field_reader.h"
+
+#include "gtest/gtest.h"
+#include "tests/agent/mock_jni_env.h"
+#include "tests/agent/mock_jvmti_env.h"
+
+using testing::_;
+using testing::DoAll;
+using testing::Eq;
+using testing::IsNull;
+using testing::NotNull;
+using testing::Test;
+using testing::Return;
+using testing::SetArgPointee;
+
+namespace devtools {
+namespace cdbg {
+
+static const jfieldID kFieldId = reinterpret_cast<jfieldID>(123);
+static const jobject kSourceObject = reinterpret_cast<jobject>(0x83467524);
+
+class JvmInstanceFieldReaderTest : public ::testing::Test {
+ protected:
+  JvmInstanceFieldReaderTest() : global_jvm_(&jvmti_, &jni_) {}
+
+  void TestReadValue(JSignature signature, const std::string& expected_value) {
+    JvmInstanceFieldReader reader(
+        "myvar",
+        kFieldId,
+        signature,
+        false,
+        read_error_);
+
+    JVariant jvariant_value;
+    FormatMessageModel error;
+    EXPECT_TRUE(reader.ReadValue(kSourceObject, &jvariant_value, &error));
+
+    EXPECT_EQ(expected_value, jvariant_value.ToString(false));
+  }
+
+ protected:
+  MockJvmtiEnv jvmti_;
+  MockJNIEnv jni_;
+  GlobalJvmEnv global_jvm_;
+  FormatMessageModel read_error_;
+};
+
+
+TEST_F(JvmInstanceFieldReaderTest, ReadBoolean) {
+  EXPECT_CALL(jni_, GetBooleanField(kSourceObject, kFieldId))
+      .WillRepeatedly(Return(true));
+
+  TestReadValue({ JType::Boolean }, "<boolean>true");
+}
+
+
+TEST_F(JvmInstanceFieldReaderTest, ReadByte) {
+  EXPECT_CALL(jni_, GetByteField(kSourceObject, kFieldId))
+      .WillRepeatedly(Return(-31));
+
+  TestReadValue({ JType::Byte }, "<byte>-31");
+}
+
+
+TEST_F(JvmInstanceFieldReaderTest, ReadChar) {
+  EXPECT_CALL(jni_, GetCharField(kSourceObject, kFieldId))
+      .WillRepeatedly(Return('A'));
+
+  TestReadValue({ JType::Char }, "<char>65");
+}
+
+
+TEST_F(JvmInstanceFieldReaderTest, ReadShort) {
+  EXPECT_CALL(jni_, GetShortField(kSourceObject, kFieldId))
+      .WillRepeatedly(Return(27123));
+
+  TestReadValue({ JType::Short }, "<short>27123");
+}
+
+
+TEST_F(JvmInstanceFieldReaderTest, ReadInt) {
+  EXPECT_CALL(jni_, GetIntField(kSourceObject, kFieldId))
+      .WillRepeatedly(Return(427));
+
+  TestReadValue({ JType::Int }, "<int>427");
+}
+
+
+TEST_F(JvmInstanceFieldReaderTest, ReadLong) {
+  EXPECT_CALL(jni_, GetLongField(kSourceObject, kFieldId))
+      .WillRepeatedly(Return(783496836454378L));
+
+  TestReadValue({ JType::Long }, "<long>783496836454378");
+}
+
+
+TEST_F(JvmInstanceFieldReaderTest, ReadFloat) {
+  EXPECT_CALL(jni_, GetFloatField(kSourceObject, kFieldId))
+      .WillRepeatedly(Return(23.4564f));
+
+  TestReadValue({ JType::Float }, "<float>23.4564");
+}
+
+
+TEST_F(JvmInstanceFieldReaderTest, ReadDouble) {
+  EXPECT_CALL(jni_, GetDoubleField(kSourceObject, kFieldId))
+      .WillRepeatedly(Return(879.345));
+
+  TestReadValue({ JType::Double }, "<double>879.345");
+}
+
+
+TEST_F(JvmInstanceFieldReaderTest, ReadNullObject) {
+  EXPECT_CALL(jni_, GetObjectField(kSourceObject, kFieldId))
+      .WillRepeatedly(Return(nullptr));
+
+  TestReadValue({ JType::Object, kJavaStringClassSignature }, "null");
+}
+
+
+TEST_F(JvmInstanceFieldReaderTest, ReadObject) {
+  const std::string kObjectSignature = "Ljava/lang/Thread;";
+  const jobject kObjectValue = reinterpret_cast<jobject>(0x87324648234L);
+
+  EXPECT_CALL(jni_, GetObjectRefType(_))
+      .WillRepeatedly(Return(JNILocalRefType));
+
+  EXPECT_CALL(jni_, GetObjectField(kSourceObject, kFieldId))
+      .WillRepeatedly(Return(kObjectValue));
+
+  JvmInstanceFieldReader reader(
+      "myvar",
+      kFieldId,
+      { JType::Object, kObjectSignature },
+      false,
+      read_error_);
+
+  JVariant jvariant_value;
+  FormatMessageModel error;
+  EXPECT_TRUE(reader.ReadValue(kSourceObject, &jvariant_value, &error));
+
+  EXPECT_EQ(JType::Object, jvariant_value.type());
+
+  jobject actual_object_value = nullptr;
+  EXPECT_TRUE(jvariant_value.get<jobject>(&actual_object_value));
+  EXPECT_EQ(kObjectValue, actual_object_value);
+
+  EXPECT_CALL(jni_, DeleteLocalRef(kObjectValue))
+      .WillOnce(Return());
+}
+
+
+TEST_F(JvmInstanceFieldReaderTest, Signature) {
+  JvmInstanceFieldReader reader(
+      "myvar",
+      kFieldId,
+      { JType::Object, "Ljava/lang/Thread;" },
+      false,
+      read_error_);
+
+  EXPECT_EQ("myvar", reader.GetName());
+  EXPECT_EQ(JType::Object, reader.GetStaticType().type);
+  EXPECT_EQ("Ljava/lang/Thread;", reader.GetStaticType().object_signature);
+}
+
+
+TEST_F(JvmInstanceFieldReaderTest, SignatureVoidType) {
+  JvmInstanceFieldReader reader(
+      "myvar",
+      kFieldId,
+      { JType::Void, "Ljava/lang/Thread;" },
+      false,
+      read_error_);
+
+  JVariant jvariant_value;
+  FormatMessageModel error;
+  EXPECT_FALSE(reader.ReadValue(kSourceObject, &jvariant_value, &error));
+  EXPECT_GT(error.format.length(), 0);
+}
+
+
+TEST_F(JvmInstanceFieldReaderTest, SignatureWithReadError) {
+  read_error_.format = "read error";
+  JvmInstanceFieldReader reader(
+      "myvar",
+      kFieldId,
+      { JType::Object, "Ljava/lang/Thread;" },
+      true,
+      read_error_);
+
+  JVariant jvariant_value;
+  FormatMessageModel error;
+  EXPECT_FALSE(reader.ReadValue(kSourceObject, &jvariant_value, &error));
+  EXPECT_EQ(read_error_, error);
+}
+
+}  // namespace cdbg
+}  // namespace devtools

--- a/tests/agent/jvm_local_variable_reader_test.cc
+++ b/tests/agent/jvm_local_variable_reader_test.cc
@@ -1,0 +1,333 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/agent/jvm_local_variable_reader.h"
+
+#include "gtest/gtest.h"
+#include "src/agent/readers_factory.h"
+#include "tests/agent/fake_jni.h"
+#include "tests/agent/mock_jvmti_env.h"
+
+using testing::_;
+using testing::DoAll;
+using testing::Eq;
+using testing::IsNull;
+using testing::NotNull;
+using testing::Test;
+using testing::Return;
+using testing::SetArgPointee;
+
+namespace devtools {
+namespace cdbg {
+
+static const jthread thread = reinterpret_cast<jthread>(0x67125374);
+static constexpr int frame_depth = 4;
+
+
+class LocalVariableReaderTest : public ::testing::Test {
+ protected:
+  LocalVariableReaderTest()
+      : fake_jni_(&jvmti_),
+        global_jvm_(&jvmti_, fake_jni_.jni()) {
+  }
+
+ protected:
+  MockJvmtiEnv jvmti_;
+  FakeJni fake_jni_;
+  GlobalJvmEnv global_jvm_;
+  FormatMessageModel read_error_;
+};
+
+
+// Verify correct evaluation of local variables of all types.
+TEST_F(LocalVariableReaderTest, Extraction) {
+  // These local references are returned directly in "GetLocalObject" mock and
+  // it is the responsibility of the LocalVariableReader to release them.
+  jobject local_ref_array_of_integers =
+      fake_jni_.CreateNewObject(FakeJni::StockClass::IntArray);
+  jobject local_ref_string = fake_jni_.CreateNewJavaString("abc");
+
+  jvmtiLocalVariableEntry table[] = {
+    {
+      100,  // start_location
+      0,  // length
+      const_cast<char*>("local_boolean"),  // name
+      const_cast<char*>("Z"),  // signature
+      nullptr,  // generic_signature
+      100  // slot
+    },
+    {
+      100,  // start_location
+      0,  // length
+      const_cast<char*>("local_char"),  // name
+      const_cast<char*>("C"),  // signature
+      nullptr,  // generic_signature
+      101  // slot
+    },
+    {
+      100,  // start_location
+      0,  // length
+      const_cast<char*>("local_byte"),  // name
+      const_cast<char*>("B"),  // signature
+      nullptr,  // generic_signature
+      102  // slot
+    },
+    {
+      100,  // start_location
+      0,  // length
+      const_cast<char*>("local_short"),  // name
+      const_cast<char*>("S"),  // signature
+      nullptr,  // generic_signature
+      103  // slot
+    },
+    {
+      100,  // start_location
+      0,  // length
+      const_cast<char*>("local_int"),  // name
+      const_cast<char*>("I"),  // signature
+      nullptr,  // generic_signature
+      104  // slot
+    },
+    {
+      100,  // start_location
+      0,  // length
+      const_cast<char*>("local_long"),  // name
+      const_cast<char*>("J"),  // signature
+      nullptr,  // generic_signature
+      105  // slot
+    },
+    {
+      100,  // start_location
+      0,  // length
+      const_cast<char*>("local_float"),  // name
+      const_cast<char*>("F"),  // signature
+      nullptr,  // generic_signature
+      106  // slot
+    },
+    {
+      100,  // start_location
+      0,  // length
+      const_cast<char*>("local_double"),  // name
+      const_cast<char*>("D"),  // signature
+      nullptr,  // generic_signature
+      107  // slot
+    },
+    {
+      100,  // start_location
+      0,  // length
+      const_cast<char*>("local_array_of_integers"),  // name
+      const_cast<char*>("[I"),  // signature
+      nullptr,  // generic_signature
+      108  // slot
+    },
+    {
+      100,  // start_location
+      0,  // length
+      const_cast<char*>("local_string"),  // name
+      const_cast<char*>("Ljava/lang/String"),  // signature
+      nullptr,  // generic_signature
+      109  // slot
+    }
+  };
+
+  // local_boolean
+  EXPECT_CALL(
+      jvmti_,
+      GetLocalInt(thread, frame_depth, 100, NotNull()))
+      .Times(1)
+      .WillRepeatedly(DoAll(SetArgPointee<3>(0), Return(JVMTI_ERROR_NONE)));
+
+  // local_char (2 byte in Java)
+  EXPECT_CALL(
+      jvmti_,
+      GetLocalInt(thread, frame_depth, 101, NotNull()))
+      .Times(1)
+      .WillRepeatedly(DoAll(SetArgPointee<3>(12345), Return(JVMTI_ERROR_NONE)));
+
+  // local_byte
+  EXPECT_CALL(
+      jvmti_,
+      GetLocalInt(thread, frame_depth, 102, NotNull()))
+      .Times(1)
+      .WillRepeatedly(DoAll(SetArgPointee<3>(-94), Return(JVMTI_ERROR_NONE)));
+
+  // local_short
+  EXPECT_CALL(
+      jvmti_,
+      GetLocalInt(thread, frame_depth, 103, NotNull()))
+      .Times(1)
+      .WillRepeatedly(DoAll(
+          SetArgPointee<3>(-25231),
+          Return(JVMTI_ERROR_NONE)));
+
+  // local_int
+  EXPECT_CALL(
+      jvmti_,
+      GetLocalInt(thread, frame_depth, 104, NotNull()))
+      .Times(1)
+      .WillRepeatedly(DoAll(
+          SetArgPointee<3>(13747862),
+          Return(JVMTI_ERROR_NONE)));
+
+  // local_long
+  EXPECT_CALL(
+      jvmti_,
+      GetLocalLong(thread, frame_depth, 105, NotNull()))
+      .Times(1)
+      .WillRepeatedly(DoAll(
+          SetArgPointee<3>(83764287364234L),
+          Return(JVMTI_ERROR_NONE)));
+
+  // local_float
+  EXPECT_CALL(
+      jvmti_,
+      GetLocalFloat(thread, frame_depth, 106, NotNull()))
+      .Times(1)
+      .WillRepeatedly(DoAll(
+          SetArgPointee<3>(12.45f),
+          Return(JVMTI_ERROR_NONE)));
+
+  // local_double
+  EXPECT_CALL(
+      jvmti_,
+      GetLocalDouble(thread, frame_depth, 107, NotNull()))
+      .Times(1)
+      .WillRepeatedly(DoAll(
+          SetArgPointee<3>(4.1273467235476),
+          Return(JVMTI_ERROR_NONE)));
+
+  // local_array_of_integers (arrays are objects in Java)
+  EXPECT_CALL(
+      jvmti_,
+      GetLocalObject(thread, frame_depth, 108, NotNull()))
+      .Times(1)
+      .WillRepeatedly(DoAll(
+          SetArgPointee<3>(local_ref_array_of_integers),
+          Return(JVMTI_ERROR_NONE)));
+
+  // local_string (strings are objects in Java)
+  EXPECT_CALL(
+      jvmti_,
+      GetLocalObject(thread, frame_depth, 109, NotNull()))
+      .Times(1)
+      .WillRepeatedly(DoAll(
+          SetArgPointee<3>(local_ref_string),
+          Return(JVMTI_ERROR_NONE)));
+
+  std::vector<std::unique_ptr<JVariant>> jvariant_result;
+
+  for (const jvmtiLocalVariableEntry& entry : table) {
+    JvmLocalVariableReader local_variable_reader(
+        entry,
+        true,
+        false,
+        read_error_);
+
+    std::unique_ptr<LocalVariableReader> reader_copy =
+        local_variable_reader.Clone();
+
+    EvaluationContext evaluation_context;
+    evaluation_context.thread = thread;
+    evaluation_context.frame_depth = frame_depth;
+
+    std::unique_ptr<JVariant> jvariant(new JVariant);
+    FormatMessageModel error;
+    EXPECT_TRUE(
+        reader_copy->ReadValue(evaluation_context, jvariant.get(), &error));
+
+    jvariant_result.push_back(std::move(jvariant));
+  }
+
+  ASSERT_EQ(10, jvariant_result.size());
+
+  EXPECT_EQ("<boolean>false", jvariant_result[0]->ToString(false));
+  EXPECT_EQ("<char>12345", jvariant_result[1]->ToString(false));
+  EXPECT_EQ("<byte>-94", jvariant_result[2]->ToString(false));
+  EXPECT_EQ("<short>-25231", jvariant_result[3]->ToString(false));
+  EXPECT_EQ("<int>13747862", jvariant_result[4]->ToString(false));
+  EXPECT_EQ("<long>83764287364234", jvariant_result[5]->ToString(false));
+  EXPECT_EQ("<float>12.45", jvariant_result[6]->ToString(false));
+  EXPECT_EQ("<double>4.127346724", jvariant_result[7]->ToString(false));
+  EXPECT_EQ("<Object>", jvariant_result[8]->ToString(false));
+  EXPECT_EQ("<Object>", jvariant_result[9]->ToString(false));
+}
+
+
+// Verify that local variable outside the scope are not evaluated.
+TEST_F(LocalVariableReaderTest, Scope) {
+  jvmtiLocalVariableEntry table[2];
+  table[0].start_location = 0;
+  table[0].length = 100;
+  table[1].start_location = 101;
+  table[1].length = 1;
+  table[0].name = table[1].name = const_cast<char*>("local");
+  table[0].signature = table[1].signature = const_cast<char*>("Z");
+  table[0].generic_signature = table[1].generic_signature = nullptr;
+  table[0].slot = table[1].slot = 0;
+
+  for (const jvmtiLocalVariableEntry& entry : table) {
+    JvmLocalVariableReader local_variable_reader(
+        entry,
+        false,
+        false,
+        read_error_);
+    ASSERT_FALSE(local_variable_reader.IsDefinedAtLocation(100));
+  }
+}
+
+
+TEST_F(LocalVariableReaderTest, IsArgument) {
+  jvmtiLocalVariableEntry entry;
+  entry.start_location = 0;
+  entry.length = 100;
+  entry.name = const_cast<char*>("local");
+  entry.signature = const_cast<char*>("Z");
+  entry.generic_signature = nullptr;
+  entry.slot = 0;
+
+  JvmLocalVariableReader argument_reader(entry, true, false, read_error_);
+  ASSERT_TRUE(argument_reader.IsArgument());
+
+  JvmLocalVariableReader local_variable_reader(
+      entry,
+      false,
+      false,
+      read_error_);
+  ASSERT_FALSE(local_variable_reader.IsArgument());
+}
+
+
+TEST_F(LocalVariableReaderTest, HasReadError) {
+  jvmtiLocalVariableEntry entry;
+  entry.start_location = 0;
+  entry.length = 100;
+  entry.name = const_cast<char*>("local");
+  entry.signature = const_cast<char*>("Z");
+  entry.generic_signature = nullptr;
+  entry.slot = 0;
+
+  read_error_.format = "read error";
+
+  JvmLocalVariableReader reader(entry, true, true, read_error_);
+  EvaluationContext evaluation_context;
+  JVariant jvariant;
+  FormatMessageModel error;
+  EXPECT_FALSE(reader.ReadValue(evaluation_context, &jvariant, &error));
+  EXPECT_EQ(read_error_, error);
+}
+
+}  // namespace cdbg
+}  // namespace devtools

--- a/tests/agent/jvm_object_array_reader_test.cc
+++ b/tests/agent/jvm_object_array_reader_test.cc
@@ -1,0 +1,145 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/agent/jvm_object_array_reader.h"
+
+#include "gtest/gtest.h"
+#include "src/agent/jni_utils.h"
+#include "src/agent/messages.h"
+#include "src/agent/model.h"
+#include "tests/agent/fake_jni.h"
+#include "tests/agent/mock_jni_env.h"
+#include "tests/agent/mock_jvmti_env.h"
+
+using testing::_;
+using testing::Invoke;
+using testing::NiceMock;
+using testing::NotNull;
+using testing::Return;
+using testing::StrictMock;
+
+namespace devtools {
+namespace cdbg {
+
+class JvmObjectArrayReaderTest : public ::testing::Test {
+ protected:
+  JvmObjectArrayReaderTest()
+      : fake_jni_(&jni_),
+        global_jvm_(fake_jni_.jvmti(), &jni_) {
+  }
+
+ protected:
+  NiceMock<MockJNIEnv> jni_;
+  FakeJni fake_jni_;
+  GlobalJvmEnv global_jvm_;
+};
+
+
+TEST_F(JvmObjectArrayReaderTest, Success) {
+  JVariant source;
+  source.attach_ref(
+      JVariant::ReferenceKind::Local,
+      fake_jni_.CreateNewJavaString("a"));
+
+  JVariant index = JVariant::Long(18);
+
+  jobject array_element_object =
+      fake_jni_.CreateNewObject(FakeJni::StockClass::MyClass2);
+
+  EXPECT_CALL(jni_, GetObjectArrayElement(NotNull(), 18))
+      .WillOnce(Return(array_element_object));
+
+  JvmObjectArrayReader reader;
+  ErrorOr<JVariant> result = reader.ReadValue(source, index);
+
+  EXPECT_FALSE(result.is_error());
+
+  jobject obj = nullptr;
+  EXPECT_TRUE(result.value().get<jobject>(&obj));
+  EXPECT_NE(nullptr, obj);
+  EXPECT_TRUE(jni_.GetObjectRefType(obj) == JNIGlobalRefType);
+}
+
+
+TEST_F(JvmObjectArrayReaderTest, BadSourceObject) {
+  JVariant source = JVariant::Boolean(true);
+  JVariant index = JVariant::Long(18);
+
+  JvmObjectArrayReader reader;
+  ErrorOr<JVariant> result = reader.ReadValue(source, index);
+
+  EXPECT_TRUE(result.is_error());
+}
+
+
+TEST_F(JvmObjectArrayReaderTest, BadIndex) {
+  JVariant source;
+  source.attach_ref(
+      JVariant::ReferenceKind::Local,
+      fake_jni_.CreateNewJavaString("a"));
+
+  JVariant index;
+  index.attach_ref(JVariant::ReferenceKind::Global, nullptr);
+
+  JvmObjectArrayReader reader;
+  ErrorOr<JVariant> result = reader.ReadValue(source, index);
+
+  EXPECT_TRUE(result.is_error());
+}
+
+
+TEST_F(JvmObjectArrayReaderTest, NullSourceObject) {
+  JVariant source = JVariant::Null();
+  JVariant index = JVariant::Long(18);
+
+  JvmObjectArrayReader reader;
+  ErrorOr<JVariant> result = reader.ReadValue(source, index);
+
+  EXPECT_TRUE(result.is_error());
+  EXPECT_EQ(NullPointerDereference, result.error_message().format);
+}
+
+
+TEST_F(JvmObjectArrayReaderTest, AccessException) {
+  JVariant source = JVariant::LocalRef(
+      fake_jni_.CreateNewJavaString("a"));
+
+  JVariant index = JVariant::Long(18);
+
+  EXPECT_CALL(jni_, GetObjectArrayElement(NotNull(), 18))
+      .WillOnce(Return(nullptr));
+
+  JniLocalRef exception_object(
+      fake_jni_.CreateNewObject(FakeJni::StockClass::MyClass3));
+
+  EXPECT_CALL(jni_, ExceptionCheck())
+      .WillOnce(Return(true));
+
+  EXPECT_CALL(jni_, ExceptionOccurred())
+      .WillOnce(Return(static_cast<jthrowable>(
+          jni_.NewLocalRef(exception_object.get()))));
+
+  JvmObjectArrayReader reader;
+  ErrorOr<JVariant> result = reader.ReadValue(source, index);
+
+  EXPECT_TRUE(result.is_error());
+  EXPECT_EQ(MethodCallExceptionOccurred, result.error_message().format);
+  EXPECT_EQ(1, result.error_message().parameters.size());
+  EXPECT_EQ("com.prod.MyClass3", result.error_message().parameters[0]);
+}
+
+}  // namespace cdbg
+}  // namespace devtools

--- a/tests/agent/jvm_object_evaluator_test.cc
+++ b/tests/agent/jvm_object_evaluator_test.cc
@@ -1,0 +1,284 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/agent/jvm_object_evaluator.h"
+
+#include "gtest/gtest.h"
+#include "jni_proxy_bigdecimal.h"
+#include "jni_proxy_biginteger.h"
+#include "jni_proxy_iterable.h"
+#include "jni_proxy_ju_map.h"
+#include "jni_proxy_ju_map_entry.h"
+#include "src/agent/instance_field_reader.h"
+#include "src/agent/messages.h"
+#include "src/agent/jni_utils.h"
+#include "src/agent/model.h"
+#include "src/agent/static_field_reader.h"
+#include "src/agent/type_evaluator.h"
+#include "tests/agent/fake_instance_field_reader.h"
+#include "tests/agent/fake_jni.h"
+#include "tests/agent/mock_class_indexer.h"
+#include "tests/agent/mock_class_metadata_reader.h"
+#include "tests/agent/mock_jvmti_env.h"
+#include "tests/agent/mock_method_caller.h"
+
+using testing::_;
+using testing::Invoke;
+using testing::ReturnRef;
+
+namespace devtools {
+namespace cdbg {
+
+class JvmObjectEvaluatorTest : public ::testing::Test {
+ protected:
+  JvmObjectEvaluatorTest()
+      : global_jvm_(fake_jni_.jvmti(), fake_jni_.jni()),
+        evaluator_(&class_metadata_reader_) {
+  }
+
+  void SetUp() override {
+    EXPECT_CALL(class_metadata_reader_, GetClassMetadata(_))
+        .WillRepeatedly(Invoke([this] (jclass cls)
+            -> const ClassMetadataReader::Entry& {
+          ClassMetadataReader::Entry* entry = new ClassMetadataReader::Entry;
+          entry->signature = JSignatureFromSignature(
+              fake_jni_.MutableClassMetadata(cls).signature);
+
+          metadata_cache_.push_back(
+              std::unique_ptr<ClassMetadataReader::Entry>(entry));
+
+          return *entry;
+        }));
+
+    CHECK(jniproxy::BindBigDecimal());
+    CHECK(jniproxy::BindBigInteger());
+    CHECK(jniproxy::BindIterable());
+    CHECK(jniproxy::BindMap());
+    CHECK(jniproxy::BindMap_Entry());
+  }
+
+  void TearDown() override {
+    jniproxy::CleanupBigDecimal();
+    jniproxy::CleanupBigInteger();
+    jniproxy::CleanupIterable();
+    jniproxy::CleanupMap();
+    jniproxy::CleanupMap_Entry();
+  }
+
+  void Evaluate(jobject obj) {
+    evaluator_.Evaluate(&method_caller_, obj, false, &members_);
+  }
+
+ protected:
+  FakeJni fake_jni_;
+  GlobalJvmEnv global_jvm_;
+  MockClassMetadataReader class_metadata_reader_;
+  MockMethodCaller method_caller_;
+  JvmObjectEvaluator evaluator_;
+
+  // Evaluation results.
+  std::vector<NamedJVariant> members_;
+
+  // "ClassMetadataReader.GetClassMetadata" returns a reference, so we keep
+  // all the entries in a vector to make it safe.
+  std::list<std::unique_ptr<ClassMetadataReader::Entry>> metadata_cache_;
+};
+
+
+TEST_F(JvmObjectEvaluatorTest, NullObject) {
+  evaluator_.Initialize();
+
+  Evaluate(nullptr);
+
+  ASSERT_EQ(1, members_.size());
+  ASSERT_EQ("", members_[0].name);
+  ASSERT_EQ(JType::Void, members_[0].value.type());
+  EXPECT_TRUE(members_[0].status.is_error);
+  EXPECT_FALSE(members_[0].status.description.format.empty());
+}
+
+
+TEST_F(JvmObjectEvaluatorTest, StringSpecialCase) {
+  evaluator_.Initialize();
+
+  JniLocalRef jstr(fake_jni_.CreateNewJavaString("abc"));
+
+  Evaluate(jstr.get());
+
+  ASSERT_EQ(1, members_.size());
+  EXPECT_EQ(WellKnownJClass::String, members_[0].well_known_jclass);
+  EXPECT_TRUE(members_[0].status.description.format.empty());
+
+  jobject actual_obj = nullptr;
+  EXPECT_TRUE(members_[0].value.get<jobject>(&actual_obj));
+  EXPECT_TRUE(fake_jni_.jni()->IsSameObject(jstr.get(), actual_obj));
+}
+
+
+TEST_F(JvmObjectEvaluatorTest, BadArray) {
+  evaluator_.Initialize();
+
+  FakeJni::ClassMetadata bad_array_metadata;
+  bad_array_metadata.signature = "[V";
+
+  JniLocalRef cls(fake_jni_.CreateNewClass(bad_array_metadata));
+  EXPECT_FALSE(cls == nullptr);
+
+  JniLocalRef obj(fake_jni_.CreateNewObject(static_cast<jclass>(cls.get())));
+  EXPECT_FALSE(obj == nullptr);
+
+  Evaluate(obj.get());
+
+  ASSERT_EQ(1, members_.size());
+  ASSERT_EQ("", members_[0].name);
+  ASSERT_EQ(JType::Void, members_[0].value.type());
+  EXPECT_TRUE(members_[0].status.is_error);
+  EXPECT_FALSE(members_[0].status.description.format.empty());
+}
+
+
+TEST_F(JvmObjectEvaluatorTest, GenericObject) {
+  evaluator_.Initialize();
+
+  FakeInstanceFieldReader fields[] = {
+    {
+      "myint",
+      { JType::Int },
+      JVariant::Int(427)
+    },
+    {
+      "mybool",
+      { JType::Boolean },
+      JVariant::Boolean(true)
+    }
+  };
+
+  ClassMetadataReader::Entry metadata;
+  metadata.signature = { JType::Object, "Lcom/prod/MyClass1;" };
+
+  for (const FakeInstanceFieldReader& field : fields) {
+    metadata.instance_fields.push_back(field.Clone());
+  }
+
+  EXPECT_CALL(class_metadata_reader_, GetClassMetadata(_))
+      .WillRepeatedly(ReturnRef(metadata));
+
+  JniLocalRef obj(fake_jni_.CreateNewObject(FakeJni::StockClass::MyClass1));
+  EXPECT_FALSE(obj == nullptr);
+
+  Evaluate(obj.get());
+
+  ASSERT_EQ(2, members_.size());
+
+  EXPECT_EQ("myint", members_[0].name);
+  EXPECT_EQ("<int>427", members_[0].value.ToString(false));
+
+  EXPECT_EQ("mybool", members_[1].name);
+  EXPECT_EQ("<boolean>true", members_[1].value.ToString(false));
+}
+
+
+TEST_F(JvmObjectEvaluatorTest, EvaluatorSelection) {
+  evaluator_.Initialize();
+
+  const struct {
+    std::string class_signature;
+    std::string expected_evaluator_name;
+  } test_cases[] = {
+    { "Lcom/prod/MyClass;", "GenericTypeEvaluator" },
+    { "[Z", "ArrayTypeEvaluator<jboolean>" },
+    { "[C", "ArrayTypeEvaluator<jchar>" },
+    { "[B", "ArrayTypeEvaluator<jbyte>" },
+    { "[S", "ArrayTypeEvaluator<jshort>" },
+    { "[I", "ArrayTypeEvaluator<jint>" },
+    { "[J", "ArrayTypeEvaluator<jlong>" },
+    { "[F", "ArrayTypeEvaluator<jfloat>" },
+    { "[D", "ArrayTypeEvaluator<jdouble>" },
+    { "[Lcom/prod/MyClass;", "ArrayTypeEvaluator<jobject>" },
+  };
+
+  for (const auto& test_case : test_cases) {
+    ClassMetadataReader::Entry metadata;
+    metadata.signature = JSignatureFromSignature(test_case.class_signature);
+
+    auto* type_evaluator = evaluator_.SelectEvaluator(nullptr, metadata);
+
+    EXPECT_EQ(
+        test_case.expected_evaluator_name,
+        type_evaluator->GetEvaluatorName())
+        << test_case.class_signature;
+  }
+}
+
+TEST_F(JvmObjectEvaluatorTest, EvaluatorSelectionForPrettyPrinters) {
+  evaluator_.Initialize();
+
+  const struct {
+    FakeJni::StockClass stock_class;
+    std::string expected_evaluator_name;
+  } test_cases[] = {
+      {FakeJni::StockClass::Iterable, "IterableTypeEvaluator"},
+      {FakeJni::StockClass::Map, "MapTypeEvaluator"},
+      {FakeJni::StockClass::MapEntry, "MapEntryTypeEvaluator"},
+      {FakeJni::StockClass::BigDecimal, "StringableTypeEvaluator"},
+      {FakeJni::StockClass::BigInteger, "StringableTypeEvaluator"},
+  };
+
+  for (const auto& test_case : test_cases) {
+    ClassMetadataReader::Entry metadata;
+    metadata.signature = JSignatureFromSignature(
+        fake_jni_.MutableStockClassMetadata(test_case.stock_class).signature);
+
+    auto* type_evaluator = evaluator_.SelectEvaluator(
+        fake_jni_.GetStockClass(test_case.stock_class), metadata);
+
+    EXPECT_EQ(test_case.expected_evaluator_name,
+              type_evaluator->GetEvaluatorName())
+        << metadata.signature.object_signature;
+  }
+}
+
+TEST_F(JvmObjectEvaluatorTest, EvaluatorSelectionForPrettyPrintersDisabled) {
+  JvmObjectEvaluator::Options options;
+  options.pretty_print_iterable = false;
+  options.pretty_print_map = false;
+  options.pretty_print_map_entry = false;
+  options.pretty_print_stringable = false;
+  evaluator_.Initialize(options);
+
+  const FakeJni::StockClass stock_classes[] = {
+      FakeJni::StockClass::Iterable,
+      FakeJni::StockClass::Map,
+      FakeJni::StockClass::MapEntry,
+      FakeJni::StockClass::BigDecimal,
+      FakeJni::StockClass::BigInteger
+  };
+
+  for (const auto stock_class : stock_classes) {
+    ClassMetadataReader::Entry metadata;
+    metadata.signature = JSignatureFromSignature(
+        fake_jni_.MutableStockClassMetadata(stock_class).signature);
+
+    auto* type_evaluator = evaluator_.SelectEvaluator(
+        fake_jni_.GetStockClass(stock_class), metadata);
+
+    EXPECT_EQ("GenericTypeEvaluator", type_evaluator->GetEvaluatorName())
+        << metadata.signature.object_signature;
+  }
+}
+
+}  // namespace cdbg
+}  // namespace devtools

--- a/tests/agent/jvm_primitive_array_reader_test.cc
+++ b/tests/agent/jvm_primitive_array_reader_test.cc
@@ -1,0 +1,196 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/agent/jvm_primitive_array_reader.h"
+
+#include "gtest/gtest.h"
+#include "src/agent/jni_utils.h"
+#include "src/agent/messages.h"
+#include "src/agent/model.h"
+#include "tests/agent/fake_jni.h"
+#include "tests/agent/mock_jni_env.h"
+#include "tests/agent/mock_jvmti_env.h"
+
+using testing::_;
+using testing::Invoke;
+using testing::NiceMock;
+using testing::NotNull;
+using testing::Return;
+using testing::SetArgPointee;
+using testing::StrictMock;
+
+namespace devtools {
+namespace cdbg {
+
+class JvmPrimitiveArrayReaderTest : public ::testing::Test {
+ protected:
+  JvmPrimitiveArrayReaderTest()
+      : fake_jni_(&jni_),
+        global_jvm_(fake_jni_.jvmti(), &jni_) {
+  }
+
+  template <typename TElement>
+  void SuccessTestCommon(const std::string& expected_result) {
+    JVariant source;
+    source.attach_ref(
+        JVariant::ReferenceKind::Local,
+        fake_jni_.CreateNewJavaString("a"));
+
+    JVariant index = JVariant::Long(73);
+
+    JvmPrimitiveArrayReader<TElement> reader;
+    ErrorOr<JVariant> result = reader.ReadValue(source, index);
+
+    EXPECT_FALSE(result.is_error());
+    EXPECT_EQ(expected_result, result.value().ToString(false));
+  }
+
+ protected:
+  NiceMock<MockJNIEnv> jni_;
+  FakeJni fake_jni_;
+  GlobalJvmEnv global_jvm_;
+};
+
+
+TEST_F(JvmPrimitiveArrayReaderTest, SuccessBoolean) {
+  EXPECT_CALL(jni_, GetBooleanArrayRegion(NotNull(), 73, 1, NotNull()))
+      .WillOnce(SetArgPointee<3>(true));
+
+  SuccessTestCommon<jboolean>("<boolean>true");
+}
+
+
+TEST_F(JvmPrimitiveArrayReaderTest, SuccessByte) {
+  EXPECT_CALL(jni_, GetByteArrayRegion(NotNull(), 73, 1, NotNull()))
+      .WillOnce(SetArgPointee<3>(-89));
+
+  SuccessTestCommon<jbyte>("<byte>-89");
+}
+
+
+TEST_F(JvmPrimitiveArrayReaderTest, SuccessChar) {
+  EXPECT_CALL(jni_, GetCharArrayRegion(NotNull(), 73, 1, NotNull()))
+      .WillOnce(SetArgPointee<3>(54321));
+
+  SuccessTestCommon<jchar>("<char>54321");
+}
+
+
+TEST_F(JvmPrimitiveArrayReaderTest, SuccessShort) {
+  EXPECT_CALL(jni_, GetShortArrayRegion(NotNull(), 73, 1, NotNull()))
+      .WillOnce(SetArgPointee<3>(-12345));
+
+  SuccessTestCommon<jshort>("<short>-12345");
+}
+
+
+TEST_F(JvmPrimitiveArrayReaderTest, SuccessInt) {
+  EXPECT_CALL(jni_, GetIntArrayRegion(NotNull(), 73, 1, NotNull()))
+      .WillOnce(SetArgPointee<3>(3487634));
+
+  SuccessTestCommon<jint>("<int>3487634");
+}
+
+
+TEST_F(JvmPrimitiveArrayReaderTest, SuccessLong) {
+  EXPECT_CALL(jni_, GetLongArrayRegion(NotNull(), 73, 1, NotNull()))
+      .WillOnce(SetArgPointee<3>(9387458734655L));
+
+  SuccessTestCommon<jlong>("<long>9387458734655");
+}
+
+
+TEST_F(JvmPrimitiveArrayReaderTest, SuccessFloat) {
+  EXPECT_CALL(jni_, GetFloatArrayRegion(NotNull(), 73, 1, NotNull()))
+      .WillOnce(SetArgPointee<3>(1.23f));
+
+  SuccessTestCommon<jfloat>("<float>1.23");
+}
+
+
+TEST_F(JvmPrimitiveArrayReaderTest, SuccessDouble) {
+  EXPECT_CALL(jni_, GetDoubleArrayRegion(NotNull(), 73, 1, NotNull()))
+      .WillOnce(SetArgPointee<3>(3.1415));
+
+  SuccessTestCommon<jdouble>("<double>3.1415");
+}
+
+
+TEST_F(JvmPrimitiveArrayReaderTest, BadSourceObject) {
+  JVariant source = JVariant::Boolean(true);
+  JVariant index = JVariant::Long(18);
+
+  JvmPrimitiveArrayReader<jint> reader;
+  ErrorOr<JVariant> result = reader.ReadValue(source, index);
+
+  EXPECT_TRUE(result.is_error());
+}
+
+
+TEST_F(JvmPrimitiveArrayReaderTest, BadIndex) {
+  JVariant source = JVariant::LocalRef(
+      fake_jni_.CreateNewJavaString("a"));
+
+  JVariant index = JVariant::Null();
+
+  JvmPrimitiveArrayReader<jint> reader;
+  ErrorOr<JVariant> result = reader.ReadValue(source, index);
+
+  EXPECT_TRUE(result.is_error());
+}
+
+
+TEST_F(JvmPrimitiveArrayReaderTest, NullSourceObject) {
+  JVariant source = JVariant::Null();
+  JVariant index = JVariant::Long(18);
+
+  JvmPrimitiveArrayReader<jint> reader;
+  ErrorOr<JVariant> result = reader.ReadValue(source, index);
+
+  EXPECT_TRUE(result.is_error());
+}
+
+
+TEST_F(JvmPrimitiveArrayReaderTest, AccessException) {
+  JVariant source = JVariant::LocalRef(
+      fake_jni_.CreateNewJavaString("a"));
+
+  JVariant index = JVariant::Long(18);
+
+  EXPECT_CALL(jni_, GetIntArrayRegion(NotNull(), 18, 1, NotNull()))
+      .WillOnce(Return());
+
+  JniLocalRef exception_object(
+      fake_jni_.CreateNewObject(FakeJni::StockClass::MyClass3));
+
+  EXPECT_CALL(jni_, ExceptionCheck())
+      .WillOnce(Return(true));
+
+  EXPECT_CALL(jni_, ExceptionOccurred())
+      .WillOnce(Return(static_cast<jthrowable>(
+          jni_.NewLocalRef(exception_object.get()))));
+
+  JvmPrimitiveArrayReader<jint> reader;
+  ErrorOr<JVariant> result = reader.ReadValue(source, index);
+
+  EXPECT_TRUE(result.is_error());
+  EXPECT_EQ(MethodCallExceptionOccurred, result.error_message().format);
+  EXPECT_EQ(1, result.error_message().parameters.size());
+  EXPECT_EQ("com.prod.MyClass3", result.error_message().parameters[0]);
+}
+
+}  // namespace cdbg
+}  // namespace devtools

--- a/tests/agent/jvm_static_field_reader_test.cc
+++ b/tests/agent/jvm_static_field_reader_test.cc
@@ -1,0 +1,231 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/agent/jvm_static_field_reader.h"
+
+#include "gtest/gtest.h"
+#include "tests/agent/fake_jni.h"
+#include "tests/agent/mock_jni_env.h"
+#include "tests/agent/mock_jvmti_env.h"
+
+using testing::_;
+using testing::Return;
+using testing::Invoke;
+
+namespace devtools {
+namespace cdbg {
+
+static const jfieldID kFieldId = reinterpret_cast<jfieldID>(123);
+
+class JvmStaticFieldReaderTest : public ::testing::Test {
+ protected:
+  JvmStaticFieldReaderTest()
+      : fake_jni_(&jni_),
+        global_jvm_(fake_jni_.jvmti(), fake_jni_.jni()) {
+  }
+
+  void SetUp() override {
+    cls_ = fake_jni_.GetStockClass(FakeJni::StockClass::MyClass1);
+  }
+
+  void TestReadValue(JSignature signature, const std::string& expected_value) {
+    JvmStaticFieldReader reader(
+        cls_,
+        "myvar",
+        kFieldId,
+        signature,
+        false,
+        read_error_);
+
+    JVariant jvariant_value;
+    FormatMessageModel error;
+    EXPECT_TRUE(reader.ReadValue(&jvariant_value, &error));
+
+    EXPECT_EQ(expected_value, jvariant_value.ToString(false));
+
+    reader.ReleaseRef();
+  }
+
+ protected:
+  testing::NiceMock<MockJNIEnv> jni_;
+  FakeJni fake_jni_;
+  GlobalJvmEnv global_jvm_;
+  FormatMessageModel read_error_;
+
+  // Fake Java class whose static fields this unit test is reading.
+  jclass cls_ { nullptr };
+};
+
+
+TEST_F(JvmStaticFieldReaderTest, ReadBoolean) {
+  EXPECT_CALL(jni_, GetStaticBooleanField(_, kFieldId))
+      .WillRepeatedly(Return(true));
+
+  TestReadValue({ JType::Boolean }, "<boolean>true");
+}
+
+
+TEST_F(JvmStaticFieldReaderTest, ReadByte) {
+  EXPECT_CALL(jni_, GetStaticByteField(_, kFieldId))
+      .WillRepeatedly(Return(-31));
+
+  TestReadValue({ JType::Byte }, "<byte>-31");
+}
+
+
+TEST_F(JvmStaticFieldReaderTest, ReadChar) {
+  EXPECT_CALL(jni_, GetStaticCharField(_, kFieldId))
+      .WillRepeatedly(Return('A'));
+
+  TestReadValue({ JType::Char }, "<char>65");
+}
+
+
+TEST_F(JvmStaticFieldReaderTest, ReadShort) {
+  EXPECT_CALL(jni_, GetStaticShortField(_, kFieldId))
+      .WillRepeatedly(Return(27123));
+
+  TestReadValue({ JType::Short }, "<short>27123");
+}
+
+
+TEST_F(JvmStaticFieldReaderTest, ReadInt) {
+  EXPECT_CALL(jni_, GetStaticIntField(_, kFieldId))
+      .WillRepeatedly(Return(427));
+
+  TestReadValue({ JType::Int }, "<int>427");
+}
+
+
+TEST_F(JvmStaticFieldReaderTest, ReadLong) {
+  EXPECT_CALL(jni_, GetStaticLongField(_, kFieldId))
+      .WillRepeatedly(Return(783496836454378L));
+
+  TestReadValue({ JType::Long }, "<long>783496836454378");
+}
+
+
+TEST_F(JvmStaticFieldReaderTest, ReadFloat) {
+  EXPECT_CALL(jni_, GetStaticFloatField(_, kFieldId))
+      .WillRepeatedly(Return(23.4564f));
+
+  TestReadValue({ JType::Float }, "<float>23.4564");
+}
+
+
+TEST_F(JvmStaticFieldReaderTest, ReadDouble) {
+  EXPECT_CALL(jni_, GetStaticDoubleField(_, kFieldId))
+      .WillRepeatedly(Return(879.345));
+
+  TestReadValue({ JType::Double }, "<double>879.345");
+}
+
+
+TEST_F(JvmStaticFieldReaderTest, ReadNullObject) {
+  const std::string kObjectSignature = "Ljava/lang/String;";
+
+  EXPECT_CALL(jni_, GetStaticObjectField(_, kFieldId))
+      .WillRepeatedly(Return(nullptr));
+
+  TestReadValue({ JType::Object, kObjectSignature }, "null");
+}
+
+
+TEST_F(JvmStaticFieldReaderTest, ReadObject) {
+  const std::string kObjectSignature = "Ljava/lang/Thread;";
+  jobject obj = fake_jni_.CreateNewObject(FakeJni::StockClass::MyClass1);
+  jobject obj_ref_copy = jni_.NewLocalRef(obj);
+
+  // The called to "GetStaticObjectField" will release "obj" ref.
+  EXPECT_CALL(jni_, GetStaticObjectField(_, kFieldId))
+      .WillOnce(Return(obj));
+
+  JvmStaticFieldReader reader(
+      cls_,
+      "myvar",
+      kFieldId,
+      { JType::Object, kObjectSignature },
+      false,
+      read_error_);
+
+  JVariant jvariant_value;
+  FormatMessageModel error;
+  EXPECT_TRUE(reader.ReadValue(&jvariant_value, &error));
+
+  EXPECT_EQ(JType::Object, jvariant_value.type());
+
+  jobject actual_object_value = nullptr;
+  EXPECT_TRUE(jvariant_value.get<jobject>(&actual_object_value));
+  EXPECT_TRUE(jni_.IsSameObject(obj_ref_copy, actual_object_value));
+
+  reader.ReleaseRef();
+
+  jni_.DeleteLocalRef(obj_ref_copy);
+}
+
+
+TEST_F(JvmStaticFieldReaderTest, Signature) {
+  JvmStaticFieldReader reader(
+      cls_,
+      "myvar",
+      kFieldId,
+      { JType::Object, "Ljava/lang/Thread;" },
+      false,
+      read_error_);
+
+  EXPECT_EQ("myvar", reader.GetName());
+  EXPECT_EQ(JType::Object, reader.GetStaticType().type);
+  EXPECT_EQ("Ljava/lang/Thread;", reader.GetStaticType().object_signature);
+
+  reader.ReleaseRef();
+}
+
+
+TEST_F(JvmStaticFieldReaderTest, SignatureVoidType) {
+  JvmStaticFieldReader reader(
+      cls_,
+      "myvar",
+      kFieldId,
+      { JType::Void, "Ljava/lang/Thread;" },
+      false,
+      read_error_);
+
+  JVariant jvariant_value;
+  FormatMessageModel error;
+  EXPECT_FALSE(reader.ReadValue(&jvariant_value, &error));
+  EXPECT_GT(error.format.length(), 0);
+
+  reader.ReleaseRef();
+}
+
+TEST_F(JvmStaticFieldReaderTest, SignatureWithReadError) {
+  read_error_.format = "read error";
+  JvmStaticFieldReader reader(
+      cls_,
+      "myvar",
+      kFieldId,
+      { JType::Object, "Ljava/lang/Thread;" },
+      true,
+      read_error_);
+
+  JVariant jvariant_value;
+  FormatMessageModel error;
+  EXPECT_FALSE(reader.ReadValue(&jvariant_value, &error));
+  EXPECT_EQ(read_error_, error);
+}
+
+}  // namespace cdbg
+}  // namespace devtools

--- a/tests/agent/log_data_collector_test.cc
+++ b/tests/agent/log_data_collector_test.cc
@@ -1,0 +1,284 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/agent/log_data_collector.h"
+
+#include "gtest/gtest.h"
+#include "mock_object.h"
+#include "src/agent/expression_evaluator.h"
+#include "src/agent/model_json.h"
+#include "src/agent/model_util.h"
+#include "tests/agent/fake_jni.h"
+#include "tests/agent/mock_jvmti_env.h"
+#include "tests/agent/mock_method_caller.h"
+#include "tests/agent/mock_object_evaluator.h"
+#include "tests/agent/mock_readers_factory.h"
+
+using testing::_;
+using testing::DoAll;
+using testing::IsNull;
+using testing::NiceMock;
+using testing::NotNull;
+using testing::Return;
+using testing::ReturnRef;
+using testing::Invoke;
+using testing::InvokeArgument;
+using testing::SetArgPointee;
+
+namespace devtools {
+namespace cdbg {
+
+static const jthread kThread = reinterpret_cast<jthread>(0x67125374);
+
+class LogDataCollectorTest : public ::testing::Test {
+ protected:
+  LogDataCollectorTest() : global_jvm_(fake_jni_.jvmti(), fake_jni_.jni()) {
+  }
+
+  void SetUp() override {
+    EXPECT_CALL(java_lang_object_, GetClass())
+        .WillRepeatedly(Return(
+            fake_jni_.GetStockClass(FakeJni::StockClass::Object)));
+
+    jniproxy::InjectObject(&java_lang_object_);
+    readers_factory_.SetUpDefault();
+  }
+
+  void TearDown() override {
+    jniproxy::InjectObject(nullptr);
+  }
+
+  std::string Process(const BreakpointModel& breakpoint) {
+    // Compile watched expressions.
+    std::vector<CompiledExpression> watches;
+    for (const std::string& expression : breakpoint.expressions) {
+      watches.push_back(CompileExpression(expression, &readers_factory_));
+    }
+
+    LogDataCollector collector;
+    collector.Collect(
+        &method_caller_,
+        &object_evaluator_,
+        watches,
+        kThread);
+
+    return collector.Format(breakpoint);
+  }
+
+  void TestCommon(std::string expected_log_message,
+                  std::unique_ptr<BreakpointModel> breakpoint) {
+    EXPECT_EQ(expected_log_message, Process(*breakpoint))
+        << "Breakpoint: " << std::endl
+        << BreakpointToPrettyJson(*breakpoint).data;
+  }
+
+ protected:
+  FakeJni fake_jni_;
+  GlobalJvmEnv global_jvm_;
+  MockReadersFactory readers_factory_;
+  MockObjectEvaluator object_evaluator_;
+  MockMethodCaller method_caller_;
+  jniproxy::MockObject java_lang_object_;
+};
+
+
+TEST_F(LogDataCollectorTest, EmptyMessage) {
+  TestCommon(
+    "",
+    BreakpointBuilder()
+      .set_id("BPID")
+      .build());
+}
+
+
+TEST_F(LogDataCollectorTest, StaticMessage) {
+  TestCommon(
+    "Hello world!",
+    BreakpointBuilder()
+      .set_id("BPID")
+      .set_log_message_format("Hello world!")
+      .build());
+}
+
+
+TEST_F(LogDataCollectorTest, Escaping) {
+  TestCommon(
+    "$abc$def$",
+    BreakpointBuilder()
+      .set_id("BPID")
+      .set_log_message_format("$$abc$$def$$")
+      .build());
+
+  TestCommon(
+    "$a$ --$",
+    BreakpointBuilder()
+      .set_id("BPID")
+      .set_log_message_format("$a$ --$")
+      .build());
+
+  TestCommon(
+    "$",
+    BreakpointBuilder()
+      .set_id("BPID")
+      .set_log_message_format("$")
+      .build());
+}
+
+
+TEST_F(LogDataCollectorTest, Substitution) {
+  TestCommon(
+    "firstsecondabcthird",
+    BreakpointBuilder()
+      .set_id("BPID")
+      .set_log_message_format("$0$1abc$2")
+      .add_expression("\"first\"")
+      .add_expression("\"second\"")
+      .add_expression("\"third\"")
+      .build());
+}
+
+
+TEST_F(LogDataCollectorTest, ErrorMessage) {
+  readers_factory_.AddFakeLocal<jint>("myint", 31);
+
+  TestCommon(
+    "wish=The primitive type int does not have a field wish",
+    BreakpointBuilder()
+      .set_id("BPID")
+      .set_log_message_format("wish=$0")
+      .add_expression("myint.wish")
+      .build());
+}
+
+
+TEST_F(LogDataCollectorTest, BadParameterIndex) {
+  TestCommon(
+    "a=Invalid parameter $1",
+    BreakpointBuilder()
+      .set_id("BPID")
+      .set_log_message_format("a=$1")
+      .add_expression("123")
+      .build());
+}
+
+
+TEST_F(LogDataCollectorTest, ManyParameters) {
+  TestCommon(
+    "8121517",
+    BreakpointBuilder()
+      .set_id("BPID")
+      .set_log_message_format("$8$12$15$17")
+      .add_expression("0")
+      .add_expression("1")
+      .add_expression("2")
+      .add_expression("3")
+      .add_expression("4")
+      .add_expression("5")
+      .add_expression("6")
+      .add_expression("7")
+      .add_expression("8")
+      .add_expression("9")
+      .add_expression("10")
+      .add_expression("11")
+      .add_expression("12")
+      .add_expression("13")
+      .add_expression("14")
+      .add_expression("15")
+      .add_expression("16")
+      .add_expression("17")
+      .build());
+}
+
+
+TEST_F(LogDataCollectorTest, ToStringSuccess) {
+  JVariant my_obj = JVariant::LocalRef(
+      fake_jni_.CreateNewObject(FakeJni::StockClass::MyClass1));
+  readers_factory_.AddFakeLocal("myObj", "LSourceObj;", my_obj);
+
+  auto& metadata =
+      fake_jni_.MutableStockClassMetadata(FakeJni::StockClass::MyClass1);
+  metadata.methods.push_back(
+      {
+        reinterpret_cast<jmethodID>(0x123123),
+        InstanceMethod("LSourceObj;", "toString", "()Ljava/lang/String;")
+      });
+
+  JVariant return_value = JVariant::LocalRef(
+      fake_jni_.CreateNewJavaString("I am a string returned by toString"));
+
+  EXPECT_CALL(method_caller_, Invoke(
+      "class = Ljava/lang/Object;, method name = toString, "
+      "method signature = ()Ljava/lang/String;, "
+      "source = <Object>, arguments = ()"))
+      .WillRepeatedly(Return(&return_value));
+
+  TestCommon(
+    "I am a string returned by toString",
+    BreakpointBuilder()
+      .set_id("BPID")
+      .set_log_message_format("$0")
+      .add_expression("myObj")
+      .build());
+}
+
+
+TEST_F(LogDataCollectorTest, ToStringFailure) {
+  JVariant my_obj = JVariant::LocalRef(
+      fake_jni_.CreateNewObject(FakeJni::StockClass::MyClass1));
+  readers_factory_.AddFakeLocal("myObj", "LSourceObj;", my_obj);
+
+  EXPECT_CALL(method_caller_, Invoke(_))
+      .WillRepeatedly(Return(FormatMessageModel { "some error" }));
+
+  EXPECT_CALL(object_evaluator_, Evaluate(NotNull(), _, _, NotNull()))
+      .WillRepeatedly(Invoke([this] (
+          MethodCaller* method_caller,
+          jobject obj,
+          bool is_watch_expression,
+          std::vector<NamedJVariant>* members) {
+        NamedJVariant var1;
+        var1.name = "myInt";
+        var1.value = JVariant::Int(42);
+        members->push_back(var1);
+
+        NamedJVariant var2;
+        var2.name = "myString";
+        var2.value = JVariant::LocalRef(
+            fake_jni_.CreateNewJavaString("hello"));
+        var2.well_known_jclass = WellKnownJClass::String;
+        members->push_back(var2);
+
+        NamedJVariant var3;
+        var3.name = "myOtherObj";
+        var3.value = JVariant::LocalRef(
+            fake_jni_.CreateNewObject(FakeJni::StockClass::MyClass2));
+        members->push_back(var3);
+      }));
+
+  TestCommon(
+    "{ myInt: 42, myString: \"hello\", myOtherObj: <Object> }",
+    BreakpointBuilder()
+      .set_id("BPID")
+      .set_log_message_format("$0")
+      .add_expression("myObj")
+      .build());
+}
+
+
+}  // namespace cdbg
+}  // namespace devtools
+
+

--- a/tests/agent/method_locals_test.cc
+++ b/tests/agent/method_locals_test.cc
@@ -1,0 +1,513 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/agent/method_locals.h"
+
+#include "gtest/gtest.h"
+#include "src/agent/common.h"
+#include "src/agent/local_variable_reader.h"
+#include "src/agent/readers_factory.h"
+#include "src/agent/structured_data_visibility_policy.h"
+#include "tests/agent/mock_jni_env.h"
+#include "tests/agent/mock_jvmti_env.h"
+
+using testing::_;
+using testing::AnyNumber;
+using testing::DoAll;
+using testing::Eq;
+using testing::IsNull;
+using testing::NotNull;
+using testing::Test;
+using testing::Return;
+using testing::ReturnNew;
+using testing::WithArgs;
+using testing::Invoke;
+using testing::InvokeArgument;
+using testing::SetArgPointee;
+
+namespace devtools {
+namespace cdbg {
+
+static const jthread thread = reinterpret_cast<jthread>(0x67125374);
+static const jmethodID method = reinterpret_cast<jmethodID>(0x8726534);
+static constexpr int frame_depth = 4;
+static constexpr char kMyClassSignature[] = "Lcom/prod/MyClass1;";
+static const jclass kMyClass = reinterpret_cast<jclass>(0x1111);
+
+
+class MethodLocalsTest : public ::testing::Test {
+ protected:
+  MethodLocalsTest() : global_jvm_(&jvmti_, &jni_) {
+  }
+
+  void SetUp() override {
+    // Ignore deallocations in most cases.
+    EXPECT_CALL(jvmti_, Deallocate(NotNull()))
+        .WillRepeatedly(Return(JVMTI_ERROR_NONE));
+
+    // Add wiring between kMyClass and method.
+    EXPECT_CALL(
+        jvmti_,
+        GetMethodDeclaringClass(method, NotNull()))
+        .WillRepeatedly(DoAll(
+            SetArgPointee<1>(kMyClass),
+            Return(JVMTI_ERROR_NONE)));
+
+    // Called when fetching class visibility.
+    EXPECT_CALL(jvmti_, GetClassSignature(_, NotNull(), nullptr))
+        .WillRepeatedly(DoAll(
+            SetArgPointee<1>(const_cast<char*>("LMyClass;")),
+            Return(JVMTI_ERROR_NONE)));
+
+    EXPECT_CALL(jni_, GetObjectRefType(kMyClass))
+        .WillRepeatedly(Return(JNILocalRefType));
+
+    EXPECT_CALL(jni_, DeleteLocalRef(kMyClass))
+        .WillRepeatedly(Return());
+  }
+
+ protected:
+  MockJvmtiEnv jvmti_;
+  MockJNIEnv jni_;
+  GlobalJvmEnv global_jvm_;
+};
+
+
+// Test factory of LocalVariableReader instances.
+TEST_F(MethodLocalsTest, LocalReadersFactory) {
+  jvmtiLocalVariableEntry table[] = {
+    {
+      100,  // start_location
+      0,  // length
+      const_cast<char*>("local_boolean"),  // name
+      const_cast<char*>("Z"),  // signature
+      nullptr,  // generic_signature
+      100  // slot
+    },
+    {
+      100,  // start_location
+      0,  // length
+      const_cast<char*>("local_long"),  // name
+      const_cast<char*>("J"),  // signature
+      nullptr,  // generic_signature
+      105  // slot
+    }
+  };
+
+  jvmtiLocalVariableEntry* ptable = table;
+
+  EXPECT_CALL(jvmti_, GetMethodModifiers(method, NotNull()))
+      .WillOnce(DoAll(
+          SetArgPointee<1>(JVM_ACC_STATIC),
+          Return(JVMTI_ERROR_NONE)));
+
+  EXPECT_CALL(
+      jvmti_,
+      GetLocalVariableTable(method, NotNull(), NotNull()))
+      .WillOnce(DoAll(
+          SetArgPointee<1>(arraysize(table)),
+          SetArgPointee<2>(ptable),
+          Return(JVMTI_ERROR_NONE)));
+
+  EXPECT_CALL(jvmti_, GetArgumentsSize(method, NotNull()))
+      .WillOnce(DoAll(
+          SetArgPointee<1>(0),
+          Return(JVMTI_ERROR_NONE)));
+
+  StructuredDataVisibilityPolicy data_visibility_policy;
+  MethodLocals method_locals(&data_visibility_policy);
+  auto entry = method_locals.GetLocalVariables(method);
+
+  EvaluationContext evaluation_context;
+  JVariant result;
+  FormatMessageModel error;
+
+  ASSERT_EQ(2, entry->locals.size());
+  EXPECT_EQ("local_boolean", entry->locals[0]->GetName());
+  EXPECT_EQ(JType::Boolean, entry->locals[0]->GetStaticType().type);
+  EXPECT_TRUE(entry->locals[0]->ReadValue(evaluation_context, &result, &error));
+  EXPECT_EQ("local_long", entry->locals[1]->GetName());
+  EXPECT_EQ(JType::Long, entry->locals[1]->GetStaticType().type);
+  EXPECT_TRUE(entry->locals[1]->ReadValue(evaluation_context, &result, &error));
+}
+
+
+TEST_F(MethodLocalsTest, LocalInstanceReaderFactory) {
+  const int table_size = 0;
+  jvmtiLocalVariableEntry* ptable = nullptr;
+
+  EXPECT_CALL(jvmti_, GetMethodModifiers(method, NotNull()))
+      .WillOnce(DoAll(
+          SetArgPointee<1>(0),
+          Return(JVMTI_ERROR_NONE)));
+
+  EXPECT_CALL(
+      jvmti_,
+      GetClassSignature(kMyClass, NotNull(), NotNull()))
+      .WillOnce(DoAll(
+          SetArgPointee<1>(const_cast<char*>(kMyClassSignature)),
+          SetArgPointee<2>(nullptr),
+          Return(JVMTI_ERROR_NONE)));
+
+  EXPECT_CALL(
+      jvmti_,
+      GetLocalVariableTable(method, NotNull(), NotNull()))
+      .WillOnce(DoAll(
+          SetArgPointee<1>(table_size),
+          SetArgPointee<2>(ptable),
+          Return(JVMTI_ERROR_NONE)));
+
+  EXPECT_CALL(jvmti_, GetArgumentsSize(method, NotNull()))
+      .WillRepeatedly(DoAll(
+          SetArgPointee<1>(0),
+          Return(JVMTI_ERROR_NONE)));
+
+  StructuredDataVisibilityPolicy data_visibility_policy;
+  MethodLocals method_locals(&data_visibility_policy);
+  auto entry = method_locals.GetLocalVariables(method);
+
+  ASSERT_TRUE(entry->local_instance != nullptr);
+  EXPECT_EQ("this", entry->local_instance->GetName());
+  EXPECT_EQ(JType::Object, entry->local_instance->GetStaticType().type);
+  EXPECT_EQ(std::string(kMyClassSignature),
+            entry->local_instance->GetStaticType().object_signature);
+  EXPECT_TRUE(entry->local_instance->IsDefinedAtLocation(0));
+  EXPECT_TRUE(entry->local_instance->IsDefinedAtLocation(0xFFFFFFFF));
+  EXPECT_TRUE(entry->local_instance->IsDefinedAtLocation(-0xFFFFFFFF));
+  EXPECT_TRUE(entry->local_instance->IsDefinedAtLocation(0x7FFFFFFFFFFFFFF0L));
+  EXPECT_TRUE(entry->local_instance->IsDefinedAtLocation(-0x7FFFFFFFFFFFFFF0L));
+}
+
+
+// Verify that local variable table is cached properly.
+TEST_F(MethodLocalsTest, Cache) {
+  const jvmtiError ret_vals[] = {
+    JVMTI_ERROR_NONE,
+    JVMTI_ERROR_ABSENT_INFORMATION,
+    JVMTI_ERROR_NATIVE_METHOD
+  };
+
+  const int table_size = 0;
+  jvmtiLocalVariableEntry* ptable = nullptr;
+
+  EXPECT_CALL(jvmti_, GetArgumentsSize(method, NotNull()))
+      .Times(AnyNumber())
+      .WillRepeatedly(DoAll(
+          SetArgPointee<1>(0),
+          Return(JVMTI_ERROR_NONE)));
+
+  for (jvmtiError ret_val : ret_vals) {
+    StructuredDataVisibilityPolicy data_visibility_policy;
+    MethodLocals method_locals(&data_visibility_policy);
+
+    EXPECT_CALL(jvmti_, GetMethodModifiers(method, NotNull()))
+        .WillOnce(DoAll(
+            SetArgPointee<1>(JVM_ACC_STATIC),
+            Return(JVMTI_ERROR_NONE)));
+
+    EXPECT_CALL(
+        jvmti_,
+        GetLocalVariableTable(method, NotNull(), NotNull()))
+        .WillOnce(DoAll(
+            SetArgPointee<1>(table_size),
+            SetArgPointee<2>(ptable),
+            Return(ret_val)));
+
+    method_locals.GetLocalVariables(method);
+    method_locals.GetLocalVariables(method);
+  }
+}
+
+
+// Verify that when method is unloaded, the cache is invalidated and memory
+// properly released.
+TEST_F(MethodLocalsTest, Unload) {
+  StructuredDataVisibilityPolicy data_visibility_policy;
+  MethodLocals method_locals(&data_visibility_policy);
+
+  const int table_size = 0;
+  jvmtiLocalVariableEntry* ptable = nullptr;
+
+  EXPECT_CALL(jvmti_, GetMethodModifiers(method, NotNull()))
+      .Times(2)
+      .WillRepeatedly(DoAll(
+          SetArgPointee<1>(JVM_ACC_STATIC),
+          Return(JVMTI_ERROR_NONE)));
+
+  EXPECT_CALL(
+      jvmti_,
+      GetLocalVariableTable(method, NotNull(), NotNull()))
+      .Times(2)
+      .WillRepeatedly(DoAll(
+          SetArgPointee<1>(table_size),
+          SetArgPointee<2>(ptable),
+          Return(JVMTI_ERROR_NONE)));
+
+  EXPECT_CALL(jvmti_, GetArgumentsSize(method, NotNull()))
+      .WillRepeatedly(DoAll(
+          SetArgPointee<1>(0),
+          Return(JVMTI_ERROR_NONE)));
+
+  method_locals.GetLocalVariables(method);
+
+  {
+    GlobalNoJni no_jni;
+    method_locals.JvmtiOnCompiledMethodUnload(method);
+  }
+
+  method_locals.GetLocalVariables(method);
+}
+
+
+// Verify that error returned by GetLocalVariableTable results in empty set and
+// that the failure is not cached.
+TEST_F(MethodLocalsTest, GetLocalVariableTable_Failure) {
+  StructuredDataVisibilityPolicy data_visibility_policy;
+  MethodLocals method_locals(&data_visibility_policy);
+
+  EXPECT_CALL(jvmti_, GetMethodModifiers(method, NotNull()))
+      .Times(2)
+      .WillRepeatedly(DoAll(
+          SetArgPointee<1>(JVM_ACC_STATIC),
+          Return(JVMTI_ERROR_NONE)));
+
+  EXPECT_CALL(
+      jvmti_,
+      GetLocalVariableTable(method, NotNull(), NotNull()))
+      .Times(2)
+      .WillRepeatedly(Return(JVMTI_ERROR_INVALID_METHODID));
+
+  EXPECT_CALL(jvmti_, GetArgumentsSize(method, NotNull()))
+      .WillRepeatedly(DoAll(
+          SetArgPointee<1>(0),
+          Return(JVMTI_ERROR_NONE)));
+
+  method_locals.GetLocalVariables(method);
+  method_locals.GetLocalVariables(method);
+}
+
+
+TEST_F(MethodLocalsTest, ArgumentsDetection) {
+  jvmtiLocalVariableEntry table[] = {
+    {
+      0,  // start_location
+      0,  // length
+      const_cast<char*>("this"),  // name
+      const_cast<char*>(kMyClassSignature),  // signature
+      nullptr,  // generic_signature
+      0  // slot
+    },
+    {
+      0,  // start_location
+      0,  // length
+      const_cast<char*>("arg1"),  // name
+      const_cast<char*>("Z"),  // signature
+      nullptr,  // generic_signature
+      1  // slot
+    },
+    {
+      0,  // start_location
+      0,  // length
+      const_cast<char*>("arg2"),  // name
+      const_cast<char*>("Z"),  // signature
+      nullptr,  // generic_signature
+      2  // slot
+    },
+    {
+      0,  // start_location
+      0,  // length
+      const_cast<char*>("local1"),  // name
+      const_cast<char*>("Z"),  // signature
+      nullptr,  // generic_signature
+      3  // slot
+    },
+    {
+      0,  // start_location
+      0,  // length
+      const_cast<char*>("local2"),  // name
+      const_cast<char*>("Z"),  // signature
+      nullptr,  // generic_signature
+      4  // slot
+    }
+  };
+
+  jvmtiLocalVariableEntry* ptable = table;
+
+  // Class has no method modifiers.
+  EXPECT_CALL(jvmti_, GetMethodModifiers(method, NotNull()))
+      .WillOnce(DoAll(
+          SetArgPointee<1>(0),
+          Return(JVMTI_ERROR_NONE)));
+
+  // Class has a signature but no generic signature.
+  EXPECT_CALL(
+      jvmti_,
+      GetClassSignature(kMyClass, NotNull(), NotNull()))
+      .WillOnce(DoAll(
+          SetArgPointee<1>(const_cast<char*>(kMyClassSignature)),
+          SetArgPointee<2>(nullptr),
+          Return(JVMTI_ERROR_NONE)));
+
+  // Local variable table is as stored above.
+  EXPECT_CALL(
+      jvmti_,
+      GetLocalVariableTable(method, NotNull(), NotNull()))
+      .WillOnce(DoAll(
+          SetArgPointee<1>(arraysize(table)),
+          SetArgPointee<2>(ptable),
+          Return(JVMTI_ERROR_NONE)));
+
+  // The first 3 local variables are method arguments.
+  EXPECT_CALL(jvmti_, GetArgumentsSize(method, NotNull()))
+      .WillOnce(DoAll(
+          SetArgPointee<1>(3),
+          Return(JVMTI_ERROR_NONE)));
+
+  StructuredDataVisibilityPolicy data_visibility_policy;
+  MethodLocals method_locals(&data_visibility_policy);
+  auto entry = method_locals.GetLocalVariables(method);
+
+  ASSERT_EQ(5, entry->locals.size());
+
+  EXPECT_EQ("this", entry->locals[0]->GetName());
+  EXPECT_TRUE(entry->locals[0]->IsArgument());
+
+  EXPECT_EQ("arg1", entry->locals[1]->GetName());
+  EXPECT_TRUE(entry->locals[1]->IsArgument());
+
+  EXPECT_EQ("arg2", entry->locals[2]->GetName());
+  EXPECT_TRUE(entry->locals[2]->IsArgument());
+
+  EXPECT_EQ("local1", entry->locals[3]->GetName());
+  EXPECT_FALSE(entry->locals[3]->IsArgument());
+
+  EXPECT_EQ("local2", entry->locals[4]->GetName());
+  EXPECT_FALSE(entry->locals[4]->IsArgument());
+
+  EXPECT_TRUE(entry->local_instance->IsArgument());
+}
+
+TEST_F(MethodLocalsTest, MemoryAllocation) {
+  // NOTE:  The string values in this table are not representative of what one
+  // would see in a real run environment; they have been modified so that values
+  // are distinct for the purposes of making memory allocation/deallocation
+  // tests more effective.
+  jvmtiLocalVariableEntry table[] = {
+      {
+          0,                                     // start_location
+          0,                                     // length
+          const_cast<char*>("this"),             // name
+          const_cast<char*>("class_signature"),  // signature
+          nullptr,                               // generic_signature
+          0                                      // slot
+      },
+      {
+          0,                          // start_location
+          0,                          // length
+          const_cast<char*>("arg1"),  // name
+          const_cast<char*>("Z1"),    // signature
+          nullptr,                    // generic_signature
+          1                           // slot
+      },
+      {
+          0,                          // start_location
+          0,                          // length
+          const_cast<char*>("arg2"),  // name
+          const_cast<char*>("Z2"),    // signature
+          const_cast<char*>("G"),     // generic_signature
+          2                           // slot
+      },
+      {
+          0,                            // start_location
+          0,                            // length
+          const_cast<char*>("local1"),  // name
+          const_cast<char*>("Z3"),      // signature
+          nullptr,                      // generic_signature
+          3                             // slot
+      },
+      {
+          0,                            // start_location
+          0,                            // length
+          const_cast<char*>("local2"),  // name
+          const_cast<char*>("Z4"),      // signature
+          nullptr,                      // generic_signature
+          4                             // slot
+      }};
+
+  jvmtiLocalVariableEntry* ptable = table;
+
+  // Override the default behaviour: Fail the test if any unexpected
+  // deallocations occur.
+  EXPECT_CALL(jvmti_, Deallocate(_)).Times(0);
+
+  // Class has no modifiers.
+  EXPECT_CALL(jvmti_, GetMethodModifiers(method, NotNull()))
+      .WillOnce(DoAll(SetArgPointee<1>(0), Return(JVMTI_ERROR_NONE)));
+
+  // Class has a signature but no generic signature.
+  EXPECT_CALL(jvmti_, GetClassSignature(kMyClass, NotNull(), NotNull()))
+      .WillOnce(DoAll(SetArgPointee<1>(const_cast<char*>(kMyClassSignature)),
+                      SetArgPointee<2>(nullptr), Return(JVMTI_ERROR_NONE)));
+
+  // Class signature must be deallocated.
+  EXPECT_CALL(jvmti_, Deallocate(reinterpret_cast<unsigned char*>(
+                          const_cast<char*>(kMyClassSignature))))
+      .WillOnce(Return(JVMTI_ERROR_NONE));
+
+  // Local variable table is as stored above.
+  EXPECT_CALL(jvmti_, GetLocalVariableTable(method, NotNull(), NotNull()))
+      .WillOnce(DoAll(SetArgPointee<1>(arraysize(table)),
+                      SetArgPointee<2>(ptable), Return(JVMTI_ERROR_NONE)));
+
+  // First 3 locals are arguments (irrelevant).
+  EXPECT_CALL(jvmti_, GetArgumentsSize(method, NotNull()))
+      .WillOnce(DoAll(SetArgPointee<1>(3), Return(JVMTI_ERROR_NONE)));
+
+  // The table needs to be deallocated.
+  EXPECT_CALL(jvmti_, Deallocate(reinterpret_cast<unsigned char*>(ptable)))
+      .WillOnce(Return(JVMTI_ERROR_NONE));
+
+  // Name, signature and generic_signature on each table entry must be
+  // deallocated separately.
+  for (const jvmtiLocalVariableEntry& entry : table) {
+    EXPECT_CALL(jvmti_, Deallocate(reinterpret_cast<unsigned char*>(
+                            const_cast<char*>(entry.name))))
+        .WillOnce(Return(JVMTI_ERROR_NONE));
+    EXPECT_CALL(jvmti_, Deallocate(reinterpret_cast<unsigned char*>(
+                            const_cast<char*>(entry.signature))))
+        .WillOnce(Return(JVMTI_ERROR_NONE));
+    // Skip generic_signature if it's null.
+    if (entry.generic_signature != nullptr) {
+      EXPECT_CALL(jvmti_, Deallocate(reinterpret_cast<unsigned char*>(
+                              const_cast<char*>(entry.generic_signature))))
+          .WillOnce(Return(JVMTI_ERROR_NONE));
+    }
+  }
+
+  // Deallocate the signature that was fetched when determining visibility.
+  EXPECT_CALL(jvmti_, Deallocate(reinterpret_cast<unsigned char*>(
+                          const_cast<char*>("LMyClass;"))))
+      .WillOnce(Return(JVMTI_ERROR_NONE));
+
+  StructuredDataVisibilityPolicy data_visibility_policy;
+  MethodLocals method_locals(&data_visibility_policy);
+  auto entry = method_locals.GetLocalVariables(method);
+
+  // No assertions necessary: EXPECT_CALLs on Deallocate are the real test.
+}
+
+}  // namespace cdbg
+}  // namespace devtools

--- a/tests/agent/mock_class_metadata_reader.h
+++ b/tests/agent/mock_class_metadata_reader.h
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DEVTOOLS_CDBG_DEBUGLETS_JAVA_MOCK_CLASS_METADATA_READER_H_
+#define DEVTOOLS_CDBG_DEBUGLETS_JAVA_MOCK_CLASS_METADATA_READER_H_
+
+#include "gmock/gmock.h"
+#include "src/agent/class_metadata_reader.h"
+
+namespace devtools {
+namespace cdbg {
+
+class MockClassMetadataReader : public ClassMetadataReader {
+ public:
+  MOCK_METHOD(const Entry&, GetClassMetadata, (jclass cls), (override));
+};
+
+
+}  // namespace cdbg
+}  // namespace devtools
+
+#endif  // DEVTOOLS_CDBG_DEBUGLETS_JAVA_MOCK_CLASS_METADATA_READER_H_
+

--- a/tests/agent/mock_class_path_lookup.h
+++ b/tests/agent/mock_class_path_lookup.h
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DEVTOOLS_CDBG_DEBUGLETS_JAVA_MOCK_CLASS_PATH_LOOKUP_H_
+#define DEVTOOLS_CDBG_DEBUGLETS_JAVA_MOCK_CLASS_PATH_LOOKUP_H_
+
+#include "gmock/gmock.h"
+#include "src/agent/class_path_lookup.h"
+
+namespace devtools {
+namespace cdbg {
+
+class MockClassPathLookup : public ClassPathLookup {
+ public:
+  MOCK_METHOD(void, ResolveSourceLocation,
+              (const std::string&, int, ResolvedSourceLocation*), (override));
+
+  MOCK_METHOD(std::vector<std::string>, FindClassesByName, (const std::string&),
+              (override));
+
+  MOCK_METHOD(std::string, ComputeDebuggeeUniquifier, (const std::string&),
+              (override));
+
+  MOCK_METHOD(std::set<std::string>, ReadApplicationResource,
+              (const std::string&), (override));
+
+  MOCK_METHOD(bool, IsMethodCallAllowed,
+              (const std::string&, const std::string&, const std::string&,
+               const bool));
+
+  MOCK_METHOD(bool, IsSafeIterable, (const std::string&));
+
+  MOCK_METHOD(bool, TransformMethod,
+              (jobject, const JavaClass&, const std::string&,
+               const std::string&, JavaClass*));
+};
+
+}  // namespace cdbg
+}  // namespace devtools
+
+#endif  // DEVTOOLS_CDBG_DEBUGLETS_JAVA_MOCK_CLASS_PATH_LOOKUP_H_

--- a/tests/agent/mock_dynamic_logger.h
+++ b/tests/agent/mock_dynamic_logger.h
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DEVTOOLS_CDBG_DEBUGLETS_JAVA_MOCK_DYNAMIC_LOGGER_H_
+#define DEVTOOLS_CDBG_DEBUGLETS_JAVA_MOCK_DYNAMIC_LOGGER_H_
+
+#include "gmock/gmock.h"
+#include "src/agent/dynamic_logger.h"
+#include "src/agent/resolved_source_location.h"
+
+namespace devtools {
+namespace cdbg {
+
+class MockDynamicLogger : public DynamicLogger {
+ public:
+  MockDynamicLogger() {
+    ON_CALL(*this, IsAvailable())
+        .WillByDefault(testing::Return(true));
+  }
+
+  MOCK_METHOD(bool, IsAvailable, (), (const, override));
+
+  MOCK_METHOD(void, Log,
+              (BreakpointModel::LogLevel, const ResolvedSourceLocation&,
+               const std::string&),
+              (override));
+};
+
+}  // namespace cdbg
+}  // namespace devtools
+
+#endif  // DEVTOOLS_CDBG_DEBUGLETS_JAVA_MOCK_DYNAMIC_LOGGER_H_

--- a/tests/agent/mock_jni_env.h
+++ b/tests/agent/mock_jni_env.h
@@ -75,15 +75,34 @@ class MockableJNIEnv : public JNIEnv {
     functions_.FindClass = &CallFindClass;
     functions_.GetArrayLength = &CallGetArrayLength;
     functions_.GetMethodID = &CallGetMethodID;
+    functions_.GetBooleanField = &CallGetBooleanField;
+    functions_.GetByteField = &CallGetByteField;
+    functions_.GetCharField = &CallGetCharField;
+    functions_.GetDoubleField = &CallGetDoubleField;
+    functions_.GetFloatField = &CallGetFloatField;
+    functions_.GetIntField = &CallGetIntField;
+    functions_.GetLongField = &CallGetLongField;
     functions_.GetObjectArrayElement = &CallGetObjectArrayElement;
     functions_.GetObjectClass = &CallGetObjectClass;
+    functions_.GetObjectField = &CallGetObjectField;
     functions_.GetObjectRefType = &CallGetObjectRefType;
     functions_.GetPrimitiveArrayCritical = &CallGetPrimitiveArrayCritical;
+    functions_.GetShortField = &CallGetShortField;
+    functions_.GetStaticBooleanField = &CallGetStaticBooleanField;
+    functions_.GetStaticByteField = &CallGetStaticByteField;
+    functions_.GetStaticCharField = &CallGetStaticCharField;
+    functions_.GetStaticDoubleField = &CallGetStaticDoubleField;
+    functions_.GetStaticFloatField = &CallGetStaticFloatField;
+    functions_.GetStaticIntField = &CallGetStaticIntField;
+    functions_.GetStaticLongField = &CallGetStaticLongField;
     functions_.GetStaticMethodID = &CallGetStaticMethodID;
+    functions_.GetStaticObjectField = &CallGetStaticObjectField;
+    functions_.GetStaticShortField = &CallGetStaticShortField;
     functions_.GetStringCritical = &CallGetStringCritical;
     functions_.GetStringLength = &CallGetStringLength;
     functions_.GetStringUTFChars = &CallGetStringUTFChars;
     functions_.GetStringUTFRegion = &CallGetStringUTFRegion;
+    functions_.GetSuperclass = &CallGetSuperclass;
     functions_.IsAssignableFrom = &CallIsAssignableFrom;
     functions_.IsInstanceOf = &CallIsInstanceOf;
     functions_.IsSameObject = &CallIsSameObject;
@@ -178,12 +197,31 @@ class MockableJNIEnv : public JNIEnv {
   virtual jthrowable ExceptionOccurred() = 0;
   virtual jclass FindClass(const char* name) = 0;
   virtual jsize GetArrayLength(jarray array) = 0;
+  virtual jboolean GetBooleanField(jobject obj, jfieldID fieldID) = 0;
+  virtual jbyte GetByteField(jobject obj, jfieldID fieldID) = 0;
+  virtual jchar GetCharField(jobject obj, jfieldID fieldID) = 0;
+  virtual jdouble GetDoubleField(jobject obj, jfieldID fieldID) = 0;
+  virtual jfloat GetFloatField(jobject obj, jfieldID fieldID) = 0;
+  virtual jint GetIntField(jobject obj, jfieldID fieldID) = 0;
+  virtual jlong GetLongField(jobject obj, jfieldID fieldID) = 0;
   virtual jmethodID GetMethodID(
       jclass clazz, const char* name, const char* sig) = 0;
   virtual jobject GetObjectArrayElement(jobjectArray array, jsize index) = 0;
   virtual jclass GetObjectClass(jobject obj) = 0;
+  virtual jobject GetObjectField(jobject obj, jfieldID fieldID) = 0;
   virtual jobjectRefType GetObjectRefType(jobject obj) = 0;
+  virtual jshort GetShortField(jobject obj, jfieldID fieldID) = 0;
+  virtual jclass GetSuperclass(jclass sub) = 0;
   virtual void* GetPrimitiveArrayCritical(jarray array, jboolean* isCopy) = 0;
+  virtual jboolean GetStaticBooleanField(jclass clazz, jfieldID fieldID) = 0;
+  virtual jbyte GetStaticByteField(jclass clazz, jfieldID fieldID) = 0;
+  virtual jchar GetStaticCharField(jclass clazz, jfieldID fieldID) = 0;
+  virtual jdouble GetStaticDoubleField(jclass clazz, jfieldID fieldID) = 0;
+  virtual jfloat GetStaticFloatField(jclass clazz, jfieldID fieldID) = 0;
+  virtual jint GetStaticIntField(jclass clazz, jfieldID fieldID) = 0;
+  virtual jlong GetStaticLongField(jclass clazz, jfieldID fieldID) = 0;
+  virtual jobject GetStaticObjectField(jclass clazz, jfieldID fieldID) = 0;
+  virtual jshort GetStaticShortField(jclass clazz, jfieldID fieldID) = 0;
   virtual jmethodID GetStaticMethodID(
       jclass clazz, const char* name, const char* sig) = 0;
   virtual const jchar* GetStringCritical(jstring str, jboolean* isCopy) = 0;
@@ -455,10 +493,39 @@ class MockableJNIEnv : public JNIEnv {
     return static_cast<MockableJNIEnv*>(env)->GetArrayLength(array);
   }
 
-  static jobject JNICALL CallGetObjectArrayElement(
-      JNIEnv* env, jobjectArray array, jsize index) {
-    return static_cast<MockableJNIEnv*>(env)->GetObjectArrayElement(
-        array, index);
+  static jboolean JNICALL CallGetBooleanField(
+      JNIEnv* env, jobject obj, jfieldID fieldID) {
+    return static_cast<MockableJNIEnv*>(env)->GetBooleanField(obj, fieldID);
+  }
+
+  static jbyte JNICALL CallGetByteField(
+      JNIEnv* env, jobject obj, jfieldID fieldID) {
+    return static_cast<MockableJNIEnv*>(env)->GetByteField(obj, fieldID);
+  }
+
+  static jchar JNICALL CallGetCharField(
+      JNIEnv* env, jobject obj, jfieldID fieldID) {
+    return static_cast<MockableJNIEnv*>(env)->GetCharField(obj, fieldID);
+  }
+
+  static jdouble JNICALL CallGetDoubleField(
+      JNIEnv* env, jobject obj, jfieldID fieldID) {
+    return static_cast<MockableJNIEnv*>(env)->GetDoubleField(obj, fieldID);
+  }
+
+  static jfloat JNICALL CallGetFloatField(
+      JNIEnv* env, jobject obj, jfieldID fieldID) {
+    return static_cast<MockableJNIEnv*>(env)->GetFloatField(obj, fieldID);
+  }
+
+  static jint JNICALL CallGetIntField(
+      JNIEnv* env, jobject obj, jfieldID fieldID) {
+    return static_cast<MockableJNIEnv*>(env)->GetIntField(obj, fieldID);
+  }
+
+  static jlong JNICALL CallGetLongField(
+      JNIEnv* env, jobject obj, jfieldID fieldID) {
+    return static_cast<MockableJNIEnv*>(env)->GetLongField(obj, fieldID);
   }
 
   static jmethodID JNICALL CallGetMethodID(
@@ -466,8 +533,19 @@ class MockableJNIEnv : public JNIEnv {
     return static_cast<MockableJNIEnv*>(env)->GetMethodID(clazz, name, sig);
   }
 
+  static jobject JNICALL CallGetObjectArrayElement(
+      JNIEnv* env, jobjectArray array, jsize index) {
+    return static_cast<MockableJNIEnv*>(env)->GetObjectArrayElement(
+        array, index);
+  }
+
   static jclass JNICALL CallGetObjectClass(JNIEnv* env, jobject obj) {
     return static_cast<MockableJNIEnv*>(env)->GetObjectClass(obj);
+  }
+
+  static jobject JNICALL CallGetObjectField(
+      JNIEnv* env, jobject obj, jfieldID fieldID) {
+    return static_cast<MockableJNIEnv*>(env)->GetObjectField(obj, fieldID);
   }
 
   static jobjectRefType JNICALL CallGetObjectRefType(JNIEnv* env, jobject obj) {
@@ -478,6 +556,65 @@ class MockableJNIEnv : public JNIEnv {
       JNIEnv* env, jarray array, jboolean* isCopy) {
     return static_cast<MockableJNIEnv*>(env)->GetPrimitiveArrayCritical(
         array, isCopy);
+  }
+
+  static jshort JNICALL CallGetShortField(
+      JNIEnv* env, jobject obj, jfieldID fieldID) {
+    return static_cast<MockableJNIEnv*>(env)->GetShortField(obj, fieldID);
+  }
+
+  static jboolean JNICALL CallGetStaticBooleanField(
+      JNIEnv* env, jclass clazz, jfieldID fieldID) {
+    return static_cast<MockableJNIEnv*>(env)->GetStaticBooleanField(
+        clazz, fieldID);
+  }
+
+  static jbyte JNICALL CallGetStaticByteField(
+      JNIEnv* env, jclass clazz, jfieldID fieldID) {
+    return static_cast<MockableJNIEnv*>(env)->GetStaticByteField(
+        clazz, fieldID);
+  }
+
+  static jchar JNICALL CallGetStaticCharField(
+      JNIEnv* env, jclass clazz, jfieldID fieldID) {
+    return static_cast<MockableJNIEnv*>(env)->GetStaticCharField(
+        clazz, fieldID);
+  }
+
+  static jdouble JNICALL CallGetStaticDoubleField(
+      JNIEnv* env, jclass clazz, jfieldID fieldID) {
+    return static_cast<MockableJNIEnv*>(env)->GetStaticDoubleField(
+        clazz, fieldID);
+  }
+
+  static jfloat JNICALL CallGetStaticFloatField(
+      JNIEnv* env, jclass clazz, jfieldID fieldID) {
+    return static_cast<MockableJNIEnv*>(env)->GetStaticFloatField(
+        clazz, fieldID);
+  }
+
+  static jint JNICALL CallGetStaticIntField(
+      JNIEnv* env, jclass clazz, jfieldID fieldID) {
+    return static_cast<MockableJNIEnv*>(env)->GetStaticIntField(
+        clazz, fieldID);
+  }
+
+  static jlong JNICALL CallGetStaticLongField(
+      JNIEnv* env, jclass clazz, jfieldID fieldID) {
+    return static_cast<MockableJNIEnv*>(env)->GetStaticLongField(
+        clazz, fieldID);
+  }
+
+  static jobject JNICALL CallGetStaticObjectField(
+      JNIEnv* env, jclass clazz, jfieldID fieldID) {
+    return static_cast<MockableJNIEnv*>(env)->GetStaticObjectField(
+        clazz, fieldID);
+  }
+
+  static jshort JNICALL CallGetStaticShortField(
+      JNIEnv* env, jclass clazz, jfieldID fieldID) {
+    return static_cast<MockableJNIEnv*>(env)->GetStaticShortField(
+        clazz, fieldID);
   }
 
   static jmethodID JNICALL CallGetStaticMethodID(
@@ -506,6 +643,10 @@ class MockableJNIEnv : public JNIEnv {
       JNIEnv* env, jstring str, jsize start, jsize len, char* buf) {
     static_cast<MockableJNIEnv*>(env)->GetStringUTFRegion(
         str, start, len, buf);
+  }
+
+  static jclass JNICALL CallGetSuperclass(JNIEnv* env, jclass sub) {
+    return static_cast<MockableJNIEnv*>(env)->GetSuperclass(sub);
   }
 
   static jboolean JNICALL CallIsAssignableFrom(
@@ -677,14 +818,46 @@ class MockJNIEnv : public MockableJNIEnv {
   MOCK_METHOD(jthrowable, ExceptionOccurred, (), (override));
   MOCK_METHOD(jclass, FindClass, (const char* name), (override));
   MOCK_METHOD(jsize, GetArrayLength, (jarray array), (override));
+  MOCK_METHOD(jboolean, GetBooleanField, (jobject obj, jfieldID fieldID),
+              (override));
+  MOCK_METHOD(jbyte, GetByteField, (jobject obj, jfieldID fieldID), (override));
+  MOCK_METHOD(jchar, GetCharField, (jobject obj, jfieldID fieldID), (override));
+  MOCK_METHOD(jdouble, GetDoubleField, (jobject obj, jfieldID fieldID),
+              (override));
+  MOCK_METHOD(jfloat, GetFloatField, (jobject obj, jfieldID fieldID),
+              (override));
+  MOCK_METHOD(jint, GetIntField, (jobject obj, jfieldID fieldID), (override));
+  MOCK_METHOD(jlong, GetLongField, (jobject obj, jfieldID fieldID), (override));
   MOCK_METHOD(jmethodID, GetMethodID,
               (jclass clazz, const char* name, const char* sig), (override));
   MOCK_METHOD(jobject, GetObjectArrayElement, (jobjectArray array, jsize index),
               (override));
   MOCK_METHOD(jclass, GetObjectClass, (jobject obj), (override));
+  MOCK_METHOD(jobject, GetObjectField, (jobject obj, jfieldID fieldID),
+              (override));
   MOCK_METHOD(jobjectRefType, GetObjectRefType, (jobject obj), (override));
   MOCK_METHOD(void*, GetPrimitiveArrayCritical,
               (jarray array, jboolean* isCopy), (override));
+  MOCK_METHOD(jshort, GetShortField, (jobject obj, jfieldID fieldID),
+              (override));
+  MOCK_METHOD(jboolean, GetStaticBooleanField, (jclass clazz, jfieldID fieldID),
+              (override));
+  MOCK_METHOD(jbyte, GetStaticByteField, (jclass clazz, jfieldID fieldID),
+              (override));
+  MOCK_METHOD(jchar, GetStaticCharField, (jclass clazz, jfieldID fieldID),
+              (override));
+  MOCK_METHOD(jdouble, GetStaticDoubleField, (jclass clazz, jfieldID fieldID),
+              (override));
+  MOCK_METHOD(jfloat, GetStaticFloatField, (jclass clazz, jfieldID fieldID),
+              (override));
+  MOCK_METHOD(jint, GetStaticIntField, (jclass clazz, jfieldID fieldID),
+              (override));
+  MOCK_METHOD(jlong, GetStaticLongField, (jclass clazz, jfieldID fieldID),
+              (override));
+  MOCK_METHOD(jobject, GetStaticObjectField, (jclass clazz, jfieldID fieldID),
+              (override));
+  MOCK_METHOD(jshort, GetStaticShortField, (jclass clazz, jfieldID fieldID),
+              (override));
   MOCK_METHOD(jmethodID, GetStaticMethodID,
               (jclass clazz, const char* name, const char* sig), (override));
   MOCK_METHOD(const jchar*, GetStringCritical, (jstring str, jboolean* isCopy),
@@ -694,6 +867,7 @@ class MockJNIEnv : public MockableJNIEnv {
               (override));
   MOCK_METHOD(void, GetStringUTFRegion,
               (jstring str, jsize start, jsize len, char* buf), (override));
+  MOCK_METHOD(jclass, GetSuperclass, (jclass sub), (override));
   MOCK_METHOD(jboolean, IsAssignableFrom, (jclass sub, jclass sup), (override));
   MOCK_METHOD(jboolean, IsInstanceOf, (jobject obj, jclass clazz), (override));
   MOCK_METHOD(jboolean, IsSameObject, (jobject obj1, jobject obj2), (override));

--- a/tests/agent/mock_jni_env.h
+++ b/tests/agent/mock_jni_env.h
@@ -75,18 +75,26 @@ class MockableJNIEnv : public JNIEnv {
     functions_.FindClass = &CallFindClass;
     functions_.GetArrayLength = &CallGetArrayLength;
     functions_.GetMethodID = &CallGetMethodID;
+    functions_.GetBooleanArrayRegion = &CallGetBooleanArrayRegion;
     functions_.GetBooleanField = &CallGetBooleanField;
+    functions_.GetByteArrayRegion = &CallGetByteArrayRegion;
     functions_.GetByteField = &CallGetByteField;
+    functions_.GetCharArrayRegion = &CallGetCharArrayRegion;
     functions_.GetCharField = &CallGetCharField;
+    functions_.GetDoubleArrayRegion = &CallGetDoubleArrayRegion;
     functions_.GetDoubleField = &CallGetDoubleField;
+    functions_.GetFloatArrayRegion = &CallGetFloatArrayRegion;
     functions_.GetFloatField = &CallGetFloatField;
+    functions_.GetIntArrayRegion = &CallGetIntArrayRegion;
     functions_.GetIntField = &CallGetIntField;
+    functions_.GetLongArrayRegion = &CallGetLongArrayRegion;
     functions_.GetLongField = &CallGetLongField;
     functions_.GetObjectArrayElement = &CallGetObjectArrayElement;
     functions_.GetObjectClass = &CallGetObjectClass;
     functions_.GetObjectField = &CallGetObjectField;
     functions_.GetObjectRefType = &CallGetObjectRefType;
     functions_.GetPrimitiveArrayCritical = &CallGetPrimitiveArrayCritical;
+    functions_.GetShortArrayRegion = &CallGetShortArrayRegion;
     functions_.GetShortField = &CallGetShortField;
     functions_.GetStaticBooleanField = &CallGetStaticBooleanField;
     functions_.GetStaticByteField = &CallGetStaticByteField;
@@ -197,12 +205,26 @@ class MockableJNIEnv : public JNIEnv {
   virtual jthrowable ExceptionOccurred() = 0;
   virtual jclass FindClass(const char* name) = 0;
   virtual jsize GetArrayLength(jarray array) = 0;
+  virtual void GetBooleanArrayRegion(
+      jbooleanArray array, jsize start, jsize len, jboolean* buf) = 0;
   virtual jboolean GetBooleanField(jobject obj, jfieldID fieldID) = 0;
+  virtual void GetByteArrayRegion(
+      jbyteArray array, jsize start, jsize len, jbyte* buf) = 0;
   virtual jbyte GetByteField(jobject obj, jfieldID fieldID) = 0;
+  virtual void GetCharArrayRegion(
+      jcharArray array, jsize start, jsize len, jchar* buf) = 0;
   virtual jchar GetCharField(jobject obj, jfieldID fieldID) = 0;
+  virtual void GetDoubleArrayRegion(
+      jdoubleArray array, jsize start, jsize len, jdouble* buf) = 0;
   virtual jdouble GetDoubleField(jobject obj, jfieldID fieldID) = 0;
+  virtual void GetFloatArrayRegion(
+      jfloatArray array, jsize start, jsize len, jfloat* buf) = 0;
   virtual jfloat GetFloatField(jobject obj, jfieldID fieldID) = 0;
+  virtual void GetIntArrayRegion(
+      jintArray array, jsize start, jsize len, jint* buf) = 0;
   virtual jint GetIntField(jobject obj, jfieldID fieldID) = 0;
+  virtual void GetLongArrayRegion(
+      jlongArray array, jsize start, jsize len, jlong* buf) = 0;
   virtual jlong GetLongField(jobject obj, jfieldID fieldID) = 0;
   virtual jmethodID GetMethodID(
       jclass clazz, const char* name, const char* sig) = 0;
@@ -210,6 +232,8 @@ class MockableJNIEnv : public JNIEnv {
   virtual jclass GetObjectClass(jobject obj) = 0;
   virtual jobject GetObjectField(jobject obj, jfieldID fieldID) = 0;
   virtual jobjectRefType GetObjectRefType(jobject obj) = 0;
+  virtual void GetShortArrayRegion(
+      jshortArray array, jsize start, jsize len, jshort* buf) = 0;
   virtual jshort GetShortField(jobject obj, jfieldID fieldID) = 0;
   virtual jclass GetSuperclass(jclass sub) = 0;
   virtual void* GetPrimitiveArrayCritical(jarray array, jboolean* isCopy) = 0;
@@ -493,9 +517,21 @@ class MockableJNIEnv : public JNIEnv {
     return static_cast<MockableJNIEnv*>(env)->GetArrayLength(array);
   }
 
+  static void JNICALL CallGetBooleanArrayRegion(
+      JNIEnv* env, jbooleanArray array, jsize start, jsize len, jboolean* buf) {
+    static_cast<MockableJNIEnv*>(env)->GetBooleanArrayRegion(
+        array, start, len, buf);
+  }
+
   static jboolean JNICALL CallGetBooleanField(
       JNIEnv* env, jobject obj, jfieldID fieldID) {
     return static_cast<MockableJNIEnv*>(env)->GetBooleanField(obj, fieldID);
+  }
+
+  static void JNICALL CallGetByteArrayRegion(
+      JNIEnv* env, jbyteArray array, jsize start, jsize len, jbyte* buf) {
+    static_cast<MockableJNIEnv*>(env)->GetByteArrayRegion(
+        array, start, len, buf);
   }
 
   static jbyte JNICALL CallGetByteField(
@@ -503,9 +539,21 @@ class MockableJNIEnv : public JNIEnv {
     return static_cast<MockableJNIEnv*>(env)->GetByteField(obj, fieldID);
   }
 
+  static void JNICALL CallGetCharArrayRegion(
+      JNIEnv* env, jcharArray array, jsize start, jsize len, jchar* buf) {
+    static_cast<MockableJNIEnv*>(env)->GetCharArrayRegion(
+        array, start, len, buf);
+  }
+
   static jchar JNICALL CallGetCharField(
       JNIEnv* env, jobject obj, jfieldID fieldID) {
     return static_cast<MockableJNIEnv*>(env)->GetCharField(obj, fieldID);
+  }
+
+  static void JNICALL CallGetDoubleArrayRegion(
+      JNIEnv* env, jdoubleArray array, jsize start, jsize len, jdouble* buf) {
+    static_cast<MockableJNIEnv*>(env)->GetDoubleArrayRegion(
+        array, start, len, buf);
   }
 
   static jdouble JNICALL CallGetDoubleField(
@@ -513,14 +561,32 @@ class MockableJNIEnv : public JNIEnv {
     return static_cast<MockableJNIEnv*>(env)->GetDoubleField(obj, fieldID);
   }
 
+  static void JNICALL CallGetFloatArrayRegion(
+      JNIEnv* env, jfloatArray array, jsize start, jsize len, jfloat* buf) {
+    static_cast<MockableJNIEnv*>(env)->GetFloatArrayRegion(
+        array, start, len, buf);
+  }
+
   static jfloat JNICALL CallGetFloatField(
       JNIEnv* env, jobject obj, jfieldID fieldID) {
     return static_cast<MockableJNIEnv*>(env)->GetFloatField(obj, fieldID);
   }
 
+  static void JNICALL CallGetIntArrayRegion(
+      JNIEnv* env, jintArray array, jsize start, jsize len, jint* buf) {
+    static_cast<MockableJNIEnv*>(env)->GetIntArrayRegion(
+        array, start, len, buf);
+  }
+
   static jint JNICALL CallGetIntField(
       JNIEnv* env, jobject obj, jfieldID fieldID) {
     return static_cast<MockableJNIEnv*>(env)->GetIntField(obj, fieldID);
+  }
+
+  static void JNICALL CallGetLongArrayRegion(
+      JNIEnv* env, jlongArray array, jsize start, jsize len, jlong* buf) {
+    static_cast<MockableJNIEnv*>(env)->GetLongArrayRegion(
+        array, start, len, buf);
   }
 
   static jlong JNICALL CallGetLongField(
@@ -556,6 +622,12 @@ class MockableJNIEnv : public JNIEnv {
       JNIEnv* env, jarray array, jboolean* isCopy) {
     return static_cast<MockableJNIEnv*>(env)->GetPrimitiveArrayCritical(
         array, isCopy);
+  }
+
+  static void JNICALL CallGetShortArrayRegion(
+      JNIEnv* env, jshortArray array, jsize start, jsize len, jshort* buf) {
+    static_cast<MockableJNIEnv*>(env)->GetShortArrayRegion(
+        array, start, len, buf);
   }
 
   static jshort JNICALL CallGetShortField(
@@ -818,15 +890,35 @@ class MockJNIEnv : public MockableJNIEnv {
   MOCK_METHOD(jthrowable, ExceptionOccurred, (), (override));
   MOCK_METHOD(jclass, FindClass, (const char* name), (override));
   MOCK_METHOD(jsize, GetArrayLength, (jarray array), (override));
+  MOCK_METHOD(void, GetBooleanArrayRegion,
+              (jbooleanArray array, jsize start, jsize len, jboolean* buf),
+              (override));
   MOCK_METHOD(jboolean, GetBooleanField, (jobject obj, jfieldID fieldID),
               (override));
+  MOCK_METHOD(void, GetByteArrayRegion,
+              (jbyteArray array, jsize start, jsize len, jbyte* buf),
+              (override));
   MOCK_METHOD(jbyte, GetByteField, (jobject obj, jfieldID fieldID), (override));
+  MOCK_METHOD(void, GetCharArrayRegion,
+              (jcharArray array, jsize start, jsize len, jchar* buf),
+              (override));
   MOCK_METHOD(jchar, GetCharField, (jobject obj, jfieldID fieldID), (override));
+  MOCK_METHOD(void, GetDoubleArrayRegion,
+              (jdoubleArray array, jsize start, jsize len, jdouble* buf),
+              (override));
   MOCK_METHOD(jdouble, GetDoubleField, (jobject obj, jfieldID fieldID),
+              (override));
+  MOCK_METHOD(void, GetFloatArrayRegion,
+              (jfloatArray array, jsize start, jsize len, jfloat* buf),
               (override));
   MOCK_METHOD(jfloat, GetFloatField, (jobject obj, jfieldID fieldID),
               (override));
+  MOCK_METHOD(void, GetIntArrayRegion,
+              (jintArray array, jsize start, jsize len, jint* buf), (override));
   MOCK_METHOD(jint, GetIntField, (jobject obj, jfieldID fieldID), (override));
+  MOCK_METHOD(void, GetLongArrayRegion,
+              (jlongArray array, jsize start, jsize len, jlong* buf),
+              (override));
   MOCK_METHOD(jlong, GetLongField, (jobject obj, jfieldID fieldID), (override));
   MOCK_METHOD(jmethodID, GetMethodID,
               (jclass clazz, const char* name, const char* sig), (override));
@@ -838,6 +930,9 @@ class MockJNIEnv : public MockableJNIEnv {
   MOCK_METHOD(jobjectRefType, GetObjectRefType, (jobject obj), (override));
   MOCK_METHOD(void*, GetPrimitiveArrayCritical,
               (jarray array, jboolean* isCopy), (override));
+  MOCK_METHOD(void, GetShortArrayRegion,
+              (jshortArray array, jsize start, jsize len, jshort* buf),
+              (override));
   MOCK_METHOD(jshort, GetShortField, (jobject obj, jfieldID fieldID),
               (override));
   MOCK_METHOD(jboolean, GetStaticBooleanField, (jclass clazz, jfieldID fieldID),

--- a/tests/agent/model_json_test.cc
+++ b/tests/agent/model_json_test.cc
@@ -1,0 +1,415 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/agent/model_json.h"
+
+#include "gtest/gtest.h"
+#include "jni_proxy_api_client_datetime.h"
+#include "src/agent/model_util.h"
+#include "tests/agent/fake_jni.h"
+#include "tests/agent/mock_jvmti_env.h"
+
+namespace devtools {
+namespace cdbg {
+
+class ModelJsonTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    ASSERT_TRUE(jniproxy::BindDateTime());
+  }
+
+  void TearDown() override {
+    jniproxy::CleanupDateTime();
+  }
+};
+
+
+template <typename T>
+static bool IsEqual(
+    const std::vector<std::unique_ptr<T>>& arr1,
+    const std::vector<std::unique_ptr<T>>& arr2) {
+  if (arr1.size() != arr2.size()) {
+    return false;
+  }
+
+  for (int i = 0; i < arr1.size(); ++i) {
+    if (!IsEqual(arr1[i], arr2[i])) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+
+template <typename T>
+static bool IsEqual(
+    const std::unique_ptr<T>& model1,
+    const std::unique_ptr<T>& model2) {
+  if ((model1 == nullptr) != (model2 == nullptr)) {
+    return false;
+  }
+
+  if (model1 != nullptr) {
+    if (!IsEqual(*model1, *model2)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+
+static bool IsEqual(
+    const FormatMessageModel& model1,
+    const FormatMessageModel& model2) {
+  return (model1.format == model2.format) &&
+         (model1.parameters == model2.parameters);
+}
+
+
+static bool IsEqual(
+    const StatusMessageModel& model1,
+    const StatusMessageModel& model2) {
+  return (model1.is_error == model2.is_error) &&
+         (model1.refers_to == model2.refers_to) &&
+         IsEqual(model1.description, model2.description);
+}
+
+
+static bool IsEqual(
+    const SourceLocationModel& model1,
+    const SourceLocationModel& model2) {
+  return (model1.path == model2.path) &&
+         (model1.line == model2.line);
+}
+
+
+static bool IsEqual(
+    const VariableModel& model1,
+    const VariableModel& model2) {
+  return (model1.name == model2.name) &&
+         (model1.value == model2.value) &&
+         (model1.type == model2.type) &&
+         (model1.var_table_index == model2.var_table_index) &&
+         IsEqual(model1.members, model2.members) &&
+         IsEqual(model1.status, model2.status);
+}
+
+
+static bool IsEqual(
+    const StackFrameModel& model1,
+    const StackFrameModel& model2) {
+  return (model1.function == model2.function) &&
+         IsEqual(model1.location, model2.location) &&
+         IsEqual(model1.arguments, model2.arguments) &&
+         IsEqual(model1.locals, model2.locals);
+}
+
+
+static bool IsEqual(
+    const BreakpointModel& model1,
+    const BreakpointModel& model2) {
+  // Note that output-only evaluated_user_id field is not used when comparing
+  // the two objects.
+  // TODO: Either ignore all output-only fields, or include
+  // evaluated_user_id in the comparison.
+  return (model1.id == model2.id) &&
+         (model1.action == model2.action) &&
+         IsEqual(model1.location, model2.location) &&
+         (model1.condition == model2.condition) &&
+         (model1.expressions == model2.expressions) &&
+         (model1.log_message_format == model2.log_message_format) &&
+         (model1.log_level == model2.log_level) &&
+         (model1.is_final_state == model2.is_final_state) &&
+         (model1.create_time == model2.create_time) &&
+         IsEqual(model1.status, model2.status) &&
+         IsEqual(model1.stack, model2.stack) &&
+         IsEqual(model1.evaluated_expressions, model2.evaluated_expressions) &&
+         IsEqual(model1.variable_table, model2.variable_table) &&
+         (model1.labels == model2.labels);
+}
+
+static std::unique_ptr<SourceLocationModel> CreateSourceLocation(
+    std::string path, int line) {
+  std::unique_ptr<SourceLocationModel> model(new SourceLocationModel);
+  model->path = std::move(path);
+  model->line = line;
+
+  return model;
+}
+
+static std::unique_ptr<BreakpointModel> CreateFullBreakpoint() {
+  std::unique_ptr<BreakpointModel> breakpoint(new BreakpointModel);
+  breakpoint->id = "id";
+  breakpoint->location = CreateSourceLocation("this/is/a/path.java", 34957834);
+  breakpoint->condition = "condition";
+  breakpoint->expressions = { "expr1", "expr2", "expr3" };
+  breakpoint->is_final_state = true;
+
+  breakpoint->stack.push_back(
+      std::unique_ptr<StackFrameModel>(new StackFrameModel {
+          "func1",
+          CreateSourceLocation("func1.java", 564345),
+          { },
+          { }
+      }));
+  breakpoint->stack.push_back(
+      std::unique_ptr<StackFrameModel>(new StackFrameModel {
+          "func2",
+          CreateSourceLocation("func2.java", 903487),
+          { },
+          { }
+      }));
+
+  breakpoint->variable_table.push_back(
+      std::unique_ptr<VariableModel>(new VariableModel));
+  breakpoint->variable_table[0]->name = "named";
+
+  breakpoint->variable_table.push_back(
+      std::unique_ptr<VariableModel>(new VariableModel));
+  breakpoint->variable_table[1]->value = "valued";
+  breakpoint->variable_table[1]->type = "typed";
+
+  breakpoint->variable_table.push_back(
+      std::unique_ptr<VariableModel>(new VariableModel));
+  breakpoint->variable_table[2]->var_table_index = 4345;
+
+  breakpoint->variable_table.push_back(
+      std::unique_ptr<VariableModel>(new VariableModel));
+  breakpoint->variable_table[3]->members.push_back(
+      std::unique_ptr<VariableModel>(new VariableModel));
+  breakpoint->variable_table[3]->members[0]->name = "myname";
+
+  breakpoint->variable_table.push_back(
+      std::unique_ptr<VariableModel>(new VariableModel));
+
+  breakpoint->labels["first"] = "one";
+  breakpoint->labels["second"] = "two";
+  breakpoint->labels["third"] = "three";
+
+  return breakpoint;
+}
+
+
+static void SerializationLoop(const BreakpointModel& breakpoint) {
+  EXPECT_TRUE(IsEqual(breakpoint, breakpoint));  // Self-test.
+
+  std::string pretty_json = BreakpointToPrettyJson(breakpoint).data;
+  std::unique_ptr<BreakpointModel> pretty_breakpoint =
+      BreakpointFromJsonString(pretty_json);
+  ASSERT_TRUE(pretty_breakpoint != nullptr);
+  EXPECT_TRUE(IsEqual(breakpoint, *pretty_breakpoint))
+      << "Pretty JSON:\n" << pretty_json;
+
+  std::string fast_json = BreakpointToJson(breakpoint).data;
+  std::unique_ptr<BreakpointModel> fast_breakpoint =
+      BreakpointFromJsonString(fast_json);
+  ASSERT_TRUE(pretty_breakpoint != nullptr);
+  EXPECT_TRUE(IsEqual(breakpoint, *fast_breakpoint))
+      << "Fast JSON:\n" << fast_json;
+}
+
+
+TEST_F(ModelJsonTest, format) {
+  EXPECT_EQ("json", BreakpointToJson(BreakpointModel()).format);
+}
+
+
+TEST_F(ModelJsonTest, FullBreakpoint) {
+  SerializationLoop(*CreateFullBreakpoint());
+}
+
+
+TEST_F(ModelJsonTest, EmptyStack) {
+  std::unique_ptr<BreakpointModel> breakpoint = CreateFullBreakpoint();
+  breakpoint->stack.clear();
+
+  SerializationLoop(*breakpoint);
+}
+
+
+TEST_F(ModelJsonTest, EmptyId) {
+  std::unique_ptr<BreakpointModel> breakpoint = CreateFullBreakpoint();
+  breakpoint->id.clear();
+
+  std::string pretty_json = BreakpointToPrettyJson(*breakpoint).data;
+  EXPECT_TRUE(BreakpointFromJsonString(pretty_json) == nullptr);
+
+  std::string fast_json = BreakpointToJson(*breakpoint).data;
+  EXPECT_TRUE(BreakpointFromJsonString(pretty_json) == nullptr);
+}
+
+
+TEST_F(ModelJsonTest, EmptyExpressions) {
+  std::unique_ptr<BreakpointModel> breakpoint = CreateFullBreakpoint();
+  breakpoint->expressions.clear();
+
+  SerializationLoop(*breakpoint);
+}
+
+
+TEST_F(ModelJsonTest, BreakpointLabels) {
+  std::unique_ptr<BreakpointModel> breakpoint = BreakpointBuilder()
+      .set_id("id")
+      .add_label("key1", "value1")
+      .add_label("key2", "value2")
+      .build();
+
+  EXPECT_EQ(
+      "{\"id\":\"id\",\"labels\":{\"key1\":\"value1\",\"key2\":\"value2\"}}\n",
+      BreakpointToJson(*breakpoint).data);
+}
+
+
+TEST_F(ModelJsonTest, EmptyBreakpointLabels) {
+  std::unique_ptr<BreakpointModel> breakpoint = CreateFullBreakpoint();
+  breakpoint->labels.clear();
+
+  SerializationLoop(*breakpoint);
+}
+
+
+TEST_F(ModelJsonTest, StatusMessage_Empty) {
+  std::unique_ptr<BreakpointModel> breakpoint = CreateFullBreakpoint();
+  breakpoint->status.reset(new StatusMessageModel());
+
+  SerializationLoop(*breakpoint);
+}
+
+
+TEST_F(ModelJsonTest, StatusMessage_NoParameters) {
+  const StatusMessageModel::Context contexts[] = {
+    StatusMessageModel::Context::UNSPECIFIED,
+    StatusMessageModel::Context::BREAKPOINT_SOURCE_LOCATION,
+    StatusMessageModel::Context::BREAKPOINT_CONDITION,
+    StatusMessageModel::Context::BREAKPOINT_EXPRESSION,
+    StatusMessageModel::Context::VARIABLE_NAME,
+    StatusMessageModel::Context::VARIABLE_VALUE
+  };
+
+  for (StatusMessageModel::Context context : contexts) {
+    std::unique_ptr<BreakpointModel> breakpoint = CreateFullBreakpoint();
+
+    breakpoint->status.reset(new StatusMessageModel());
+    breakpoint->status->is_error = true;
+    breakpoint->status->refers_to = context;
+    breakpoint->status->description.format = "bad condition";
+
+    SerializationLoop(*breakpoint);
+  }
+}
+
+
+TEST_F(ModelJsonTest, StatusMessage_Full) {
+  std::unique_ptr<BreakpointModel> breakpoint = CreateFullBreakpoint();
+
+  breakpoint->status.reset(new StatusMessageModel());
+  breakpoint->status->is_error = false;
+  breakpoint->status->refers_to = StatusMessageModel::Context::VARIABLE_NAME;
+  breakpoint->status->description.format =
+      "$0 is a bad variable because $1 and $2";
+  breakpoint->status->description.parameters =
+      { "fish", "some reason", "just excuse" };
+
+  SerializationLoop(*breakpoint);
+}
+
+
+TEST_F(ModelJsonTest, VariableStatusMessage) {
+  std::unique_ptr<StatusMessageModel> status(new StatusMessageModel());
+  status->is_error = true;
+  status->description.format = "variable doesn't work";
+
+  std::unique_ptr<BreakpointModel> breakpoint = CreateFullBreakpoint();
+  breakpoint->variable_table[4]->status = std::move(status);
+
+  SerializationLoop(*breakpoint);
+}
+
+
+TEST_F(ModelJsonTest, BreakpointAction) {
+  std::unique_ptr<BreakpointModel> breakpoint = CreateFullBreakpoint();
+
+  breakpoint->action = BreakpointModel::Action::CAPTURE;
+  SerializationLoop(*breakpoint);
+
+  breakpoint->action = BreakpointModel::Action::LOG;
+  SerializationLoop(*breakpoint);
+}
+
+
+TEST_F(ModelJsonTest, BreakpointLogMessageFormat) {
+  std::unique_ptr<BreakpointModel> breakpoint = CreateFullBreakpoint();
+
+  breakpoint->log_message_format = "a = $0, b = $1";
+  SerializationLoop(*breakpoint);
+}
+
+
+TEST_F(ModelJsonTest, BreakpointLogLevel) {
+  std::unique_ptr<BreakpointModel> breakpoint = CreateFullBreakpoint();
+
+  breakpoint->log_level = BreakpointModel::LogLevel::INFO;
+  SerializationLoop(*breakpoint);
+
+  breakpoint->log_level = BreakpointModel::LogLevel::WARNING;
+  SerializationLoop(*breakpoint);
+
+  breakpoint->log_level = BreakpointModel::LogLevel::ERROR;
+  SerializationLoop(*breakpoint);
+}
+
+
+TEST_F(ModelJsonTest, BreakpointCreateTime) {
+  std::unique_ptr<BreakpointModel> breakpoint = CreateFullBreakpoint();
+
+  breakpoint->create_time.seconds = 1444163838L;
+  breakpoint->create_time.nanos = 893000000;  // Rfc3339 timestamp parser only
+                                              // supports millisecond precision.
+  SerializationLoop(*breakpoint);
+
+  breakpoint->create_time.seconds = 3489578;
+  breakpoint->create_time.nanos = TimestampModel().nanos;
+  SerializationLoop(*breakpoint);
+}
+
+
+TEST_F(ModelJsonTest, UserId_Empty) {
+  std::unique_ptr<BreakpointModel> breakpoint = CreateFullBreakpoint();
+  breakpoint->evaluated_user_id.reset(new UserIdModel());
+
+  SerializationLoop(*breakpoint);
+}
+
+
+TEST_F(ModelJsonTest, UserId_Full) {
+  std::unique_ptr<BreakpointModel> breakpoint = CreateFullBreakpoint();
+
+  breakpoint->evaluated_user_id.reset(new UserIdModel());
+  breakpoint->evaluated_user_id->kind = "test_user";
+  breakpoint->evaluated_user_id->id = "12345";
+
+  SerializationLoop(*breakpoint);
+
+  // Also verify that evaluated_user_id field is not serialized to JSON.
+  std::string json_breakpoint = BreakpointToJson(*breakpoint).data;
+  EXPECT_EQ(std::string::npos, json_breakpoint.find("evaluated_user_id"))
+      << "Unexpected JSON data: " << json_breakpoint;
+}
+
+}  // namespace cdbg
+}  // namespace devtools


### PR DESCRIPTION
Adds the following unit tests:
* format_queue_test
* generic_type_evaluator_test
* glob_data_visibility_policy_test
* jni_utils_test
* jvm_breakpoint_test
* jvm_breakpoints_manager_test
* jvm_class_indexer_test
* jvm_class_metadata_reader_test
* jvm_instance_field_reader_test
* jvm_local_variable_reader_test
* jvm_object_array_reader_test
* jvm_object_evaluator_test
* jvm_primitive_array_reader_test
* jvm_static_field_reader_test
* log_data_collector_test
* method_locals_test
* model_json_test