### PR TITLE
cleanup: Use data() to access pointer to string data.

### DIFF
--- a/tests/agent/encoding_util_test.cc
+++ b/tests/agent/encoding_util_test.cc
@@ -305,12 +305,12 @@ static struct {
 
 TEST(EncodingUtil, Base64Encode) {
   for (const auto& tc : base64_tests) {
-    std::string result = Base64Encode(&tc.plaintext[0], tc.plaintext.size());
+    std::string result = Base64Encode(tc.plaintext.data(), tc.plaintext.size());
     EXPECT_EQ(tc.cyphertext, result);
   }
 
   for (const auto& tc : base64_extra_tests) {
-    std::string result = Base64Encode(&tc.plaintext[0], tc.plaintext.size());
+    std::string result = Base64Encode(tc.plaintext.data(), tc.plaintext.size());
     EXPECT_EQ(tc.cyphertext, result);
   }
 


### PR DESCRIPTION
Updates a unit test to use the data() string member function instead of using &str[0] to get a pointer to the string contents.