### PR TITLE
feat: Add slf4j-simple dependency to internals.jar

### DIFF
--- a/src/agent/internals/pom.xml
+++ b/src/agent/internals/pom.xml
@@ -49,6 +49,11 @@
       <artifactId>firebase-admin</artifactId>
       <version>9.0.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.36</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
The Firebase Admin SDK uses slf4j for logging. What this means is that in order to see logging information out of the sdk library a sl4j binding must be found.

Here we use the slf4j-simple logger, which emits the logs to stderr. One simple way to configure it is to add
`-Dorg.slf4j.simpleLogger.defaultLogLevel=debug` to the java command invocation.

See here for more information:
* https://www.slf4j.org/api/org/slf4j/simple/SimpleLogger.html
* https://www.slf4j.org/manual.html

To note, this is bundled into the agent's internals.jar file that the agent loads for itself and is kept isolated from the application.