### PR TITLE
build: Fix bazel test builds when using Bazel 6

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -60,8 +60,8 @@ http_archive(
 
 http_archive(
   name = "com_google_googletest",
-  urls = ["https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip"],
-  strip_prefix = "googletest-609281088cfefc76f9d0ce82e1ff6c30cc3591e5",
+  urls = ["https://github.com/google/googletest/archive/7107c441885900fedb8458a96bddca16e9768573.zip"],
+  strip_prefix = "googletest-7107c441885900fedb8458a96bddca16e9768573",
 )
 
 http_archive(


### PR DESCRIPTION
Fixes #60

Pulling in a newer version of the googletest repo addresses the issue. To note, the latest version was not used, as it requires C++14, and would require more changes to support. The commit chosen is from July 1 2022, which is the last commit that does not require C++14 to build.