### PR TITLE
fix: Breakpoint expiry now uses create time

### DIFF
--- a/src/agent/jvm_breakpoint.cc
+++ b/src/agent/jvm_breakpoint.cc
@@ -205,12 +205,12 @@ void JvmBreakpoint::Initialize() {
 
   // Schedule breakpoint cancellation.
   time_t expiration_time_base;
-  if (GetCreateTimestamp(*definition_) == kUnspecifiedTimestamp) {
+  if (model_util::GetCreateTimestamp(*definition_) == kUnspecifiedTimestamp) {
     // It really shouldn't happen, but if it does start computing expiration
     // time from this moment.
     expiration_time_base = scheduler_->CurrentTime();
   } else {
-    expiration_time_base = GetCreateTimestamp(*definition_).seconds;
+    expiration_time_base = model_util::GetCreateTimestamp(*definition_).seconds;
   }
 
   int32_t expiration_seconds = absl::GetFlag(FLAGS_breakpoint_expiration_sec);

--- a/src/agent/jvm_breakpoint.cc
+++ b/src/agent/jvm_breakpoint.cc
@@ -205,12 +205,12 @@ void JvmBreakpoint::Initialize() {
 
   // Schedule breakpoint cancellation.
   time_t expiration_time_base;
-  if (definition_->create_time == kUnspecifiedTimestamp) {
+  if (GetCreateTimestamp(*definition_) == kUnspecifiedTimestamp) {
     // It really shouldn't happen, but if it does start computing expiration
     // time from this moment.
     expiration_time_base = scheduler_->CurrentTime();
   } else {
-    expiration_time_base = definition_->create_time.seconds;
+    expiration_time_base = GetCreateTimestamp(*definition_).seconds;
   }
 
   int32_t expiration_seconds = absl::GetFlag(FLAGS_breakpoint_expiration_sec);

--- a/src/agent/model.h
+++ b/src/agent/model.h
@@ -144,7 +144,16 @@ struct BreakpointModel {
   std::string log_message_format;
   LogLevel log_level = LogLevel::INFO;
   bool is_final_state = false;
+
+  // The Cloud Debugger GCP Backend version of the service uses a field called
+  // 'create_time' to represent the breakpoint creation time. The OSS Snapshot
+  // Debugger Firebase Backend version of the service uses a field called
+  // 'create_time_unix_msec'. For simplicity when serializing we treat them
+  // seperately and they will either get serialized or not depending on if they
+  // have a real value or not.
   TimestampModel create_time;
+  TimestampModel create_time_unix_msec;
+
   std::unique_ptr<StatusMessageModel> status;
   std::vector<std::unique_ptr<StackFrameModel>> stack;
   std::vector<std::unique_ptr<VariableModel>> evaluated_expressions;

--- a/src/agent/model_util.h
+++ b/src/agent/model_util.h
@@ -675,11 +675,15 @@ inline bool operator!= (const TimestampModel& t1, const TimestampModel& t2) {
   return !(t1 == t2);
 }
 
+namespace model_util {
+
 inline TimestampModel GetCreateTimestamp(const BreakpointModel& model) {
   return (model.create_time != kUnspecifiedTimestamp)
              ? model.create_time
              : model.create_time_unix_msec;
 }
+
+}  // namespace model_util
 
 inline bool operator== (const DurationModel& d1, const DurationModel& d2) {
   return (d1.seconds == d2.seconds) && (d1.nanos == d2.nanos);

--- a/src/agent/model_util.h
+++ b/src/agent/model_util.h
@@ -418,6 +418,7 @@ class BreakpointBuilder {
     set_is_final_state(source.is_final_state);
 
     set_create_time(source.create_time);
+    set_create_time_unix_msec(source.create_time_unix_msec);
 
     if (source.status != nullptr) {
       set_status(StatusMessageBuilder(*source.status).build());
@@ -498,6 +499,11 @@ class BreakpointBuilder {
 
   BreakpointBuilder& set_create_time(TimestampModel timestamp) {
     data_->create_time = timestamp;
+    return *this;
+  }
+
+  BreakpointBuilder& set_create_time_unix_msec(TimestampModel timestamp) {
+    data_->create_time_unix_msec = timestamp;
     return *this;
   }
 
@@ -660,7 +666,6 @@ class ErrorOr {
   FormatMessageModel error_message_;
 };
 
-
 inline bool operator== (const TimestampModel& t1, const TimestampModel& t2) {
   return (t1.seconds == t2.seconds) && (t1.nanos == t2.nanos);
 }
@@ -668,6 +673,12 @@ inline bool operator== (const TimestampModel& t1, const TimestampModel& t2) {
 
 inline bool operator!= (const TimestampModel& t1, const TimestampModel& t2) {
   return !(t1 == t2);
+}
+
+inline TimestampModel GetCreateTimestamp(const BreakpointModel& model) {
+  return (model.create_time != kUnspecifiedTimestamp)
+             ? model.create_time
+             : model.create_time_unix_msec;
 }
 
 inline bool operator== (const DurationModel& d1, const DurationModel& d2) {

--- a/tests/agent/jvm_breakpoint_test.cc
+++ b/tests/agent/jvm_breakpoint_test.cc
@@ -575,6 +575,19 @@ TEST_F(JvmBreakpointTest, BreakpointExpirationWithCreatedTime) {
   scheduler_.Process();
 }
 
+TEST_F(JvmBreakpointTest, BreakpointExpirationWithCreatedTimeUnixMsec) {
+  Create(BreakpointBuilder(*breakpoint_template_)
+             .set_create_time_unix_msec(
+                 TimestampBuilder::Build(simulated_time_sec_))
+             .build());
+
+  EXPECT_CALL(breakpoints_manager_, CompleteBreakpoint("test_breakpoint_id"))
+      .WillOnce(Return());
+
+  simulated_time_sec_ += absl::GetFlag(FLAGS_breakpoint_expiration_sec);
+  scheduler_.Process();
+}
+
 TEST_F(JvmBreakpointTest, BreakpointExpirationNoCreatedTime) {
   Create(BreakpointBuilder(*breakpoint_template_).build());
 

--- a/tests/agent/model_json_test.cc
+++ b/tests/agent/model_json_test.cc
@@ -379,7 +379,8 @@ TEST_F(ModelJsonTest, BreakpointCreateTime) {
   std::unique_ptr<BreakpointModel> breakpoint = CreateFullBreakpoint();
 
   breakpoint->create_time.seconds = 1444163838L;
-  breakpoint->create_time.nanos = 893000000;
+  breakpoint->create_time.nanos = 893000000;  // Rfc3339 timestamp parser only
+                                              // supports millisecond precision.
   SerializationLoop(*breakpoint);
 
   breakpoint->create_time.seconds = 3489578;

--- a/tests/agent/model_json_test.cc
+++ b/tests/agent/model_json_test.cc
@@ -136,6 +136,7 @@ static bool IsEqual(
          (model1.log_level == model2.log_level) &&
          (model1.is_final_state == model2.is_final_state) &&
          (model1.create_time == model2.create_time) &&
+         (model1.create_time_unix_msec == model2.create_time_unix_msec) &&
          IsEqual(model1.status, model2.status) &&
          IsEqual(model1.stack, model2.stack) &&
          IsEqual(model1.evaluated_expressions, model2.evaluated_expressions) &&
@@ -378,12 +379,24 @@ TEST_F(ModelJsonTest, BreakpointCreateTime) {
   std::unique_ptr<BreakpointModel> breakpoint = CreateFullBreakpoint();
 
   breakpoint->create_time.seconds = 1444163838L;
-  breakpoint->create_time.nanos = 893000000;  // Rfc3339 timestamp parser only
-                                              // supports millisecond precision.
+  breakpoint->create_time.nanos = 893000000;
   SerializationLoop(*breakpoint);
 
   breakpoint->create_time.seconds = 3489578;
   breakpoint->create_time.nanos = TimestampModel().nanos;
+  SerializationLoop(*breakpoint);
+}
+
+
+TEST_F(ModelJsonTest, BreakpointCreateTimeUnixMsec) {
+  std::unique_ptr<BreakpointModel> breakpoint = CreateFullBreakpoint();
+
+  breakpoint->create_time_unix_msec.seconds = 1444163838L;
+  breakpoint->create_time_unix_msec.nanos = 893000000;
+  SerializationLoop(*breakpoint);
+
+  breakpoint->create_time_unix_msec.seconds = 3489578;
+  breakpoint->create_time_unix_msec.nanos = TimestampModel().nanos;
   SerializationLoop(*breakpoint);
 }
 

--- a/tests/agent/model_util_test.cc
+++ b/tests/agent/model_util_test.cc
@@ -481,9 +481,9 @@ TEST_F(ModelUtilTest, GetCreateTimestamp) {
                  .set_create_time_unix_msec(kUnspecifiedTimestamp)
                  .build();
 
-  EXPECT_THAT(GetCreateTimestamp(*bp1), Eq(test_timestamp));
-  EXPECT_THAT(GetCreateTimestamp(*bp2), Eq(test_timestamp));
-  EXPECT_THAT(GetCreateTimestamp(*bp3), Eq(kUnspecifiedTimestamp));
+  EXPECT_THAT(model_util::GetCreateTimestamp(*bp1), Eq(test_timestamp));
+  EXPECT_THAT(model_util::GetCreateTimestamp(*bp2), Eq(test_timestamp));
+  EXPECT_THAT(model_util::GetCreateTimestamp(*bp3), Eq(kUnspecifiedTimestamp));
 }
 
 TEST_F(ModelUtilTest, SetBreakpointLabels) {


### PR DESCRIPTION
Updated the internal agent code and the breakpoint json model to support the `createTimeUnixMsec` field. This field is used in the Firebase Backend version of the agent to represent the breakpoint creation time. When determining the breakpoint expiry this field will now be used if present.

Fixes #66 