### PR TITLE
chore: Release version 4.0

### DIFF
--- a/src/agent/internals/src/main/java/com/google/devtools/cdbg/debuglets/java/GcpDebugletVersion.java
+++ b/src/agent/internals/src/main/java/com/google/devtools/cdbg/debuglets/java/GcpDebugletVersion.java
@@ -21,10 +21,10 @@ public final class GcpDebugletVersion {
    * <p>All agents of the same major version are compatible with each other. In other words an
    * application can mix different agents with the same major version within the same debuggee.
    */
-  public static final int MAJOR_VERSION = 3;
+  public static final int MAJOR_VERSION = 4;
 
   /** Minor version of the agent. */
-  public static final int MINOR_VERSION = 3;
+  public static final int MINOR_VERSION = 0;
 
   /** Debugger agent version string in the format of MAJOR.MINOR. */
   public static final String VERSION = String.format("%d.%d", MAJOR_VERSION, MINOR_VERSION);


### PR DESCRIPTION
This version talks to the Firebase RTDB backend by default.